### PR TITLE
[CELADON] UP2 board enable

### DIFF
--- a/cel_apl/BoardConfig.mk
+++ b/cel_apl/BoardConfig.mk
@@ -392,10 +392,6 @@ TARGET_ARCH := x86
 TARGET_CPU_ABI := x86
 endif
 ##############################################################
-# Source: device/intel/mixins/groups/cpuset/4cores/BoardConfig.mk
-##############################################################
-ENABLE_CPUSETS := true
-##############################################################
 # Source: device/intel/mixins/groups/rfkill/true/BoardConfig.mk
 ##############################################################
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/rfkill

--- a/cel_apl/init.rc
+++ b/cel_apl/init.rc
@@ -537,14 +537,14 @@ on post-fs
     insmod /vendor/lib/modules/kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
 
 ##############################################################
-# Source: device/intel/mixins/groups/cpuset/4cores/init.rc
+# Source: device/intel/mixins/groups/cpuset/autocores/init.rc
 ##############################################################
 on late-init
-    write /dev/cpuset/foreground/cpus 0-3
-    write /dev/cpuset/background/cpus 0-3
-    write /dev/cpuset/system-background/cpus 0-3
-    write /dev/cpuset/top-app/cpus 0-3
-    write /dev/cpuset/foreground/boost/cpus 0-3
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/system-background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/top-app/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/boost/cpus
 ##############################################################
 # Source: device/intel/mixins/groups/rfkill/true/init.rc
 ##############################################################

--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -23,7 +23,7 @@ boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_tim
 audio: project-celadon
 wlan: iwlwifi
 cpu-arch: skl
-cpuset: 4cores
+cpuset: autocores
 rfkill: true(force_disable=)
 dexpreopt: enabled
 disk-bus: auto

--- a/celadon/BoardConfig.mk
+++ b/celadon/BoardConfig.mk
@@ -386,10 +386,6 @@ TARGET_ARCH := x86
 TARGET_CPU_ABI := x86
 endif
 ##############################################################
-# Source: device/intel/mixins/groups/cpuset/4cores/BoardConfig.mk
-##############################################################
-ENABLE_CPUSETS := true
-##############################################################
 # Source: device/intel/mixins/groups/rfkill/true/BoardConfig.mk
 ##############################################################
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/rfkill

--- a/celadon/init.rc
+++ b/celadon/init.rc
@@ -537,14 +537,14 @@ on post-fs
     insmod /vendor/lib/modules/kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
 
 ##############################################################
-# Source: device/intel/mixins/groups/cpuset/4cores/init.rc
+# Source: device/intel/mixins/groups/cpuset/autocores/init.rc
 ##############################################################
 on late-init
-    write /dev/cpuset/foreground/cpus 0-3
-    write /dev/cpuset/background/cpus 0-3
-    write /dev/cpuset/system-background/cpus 0-3
-    write /dev/cpuset/top-app/cpus 0-3
-    write /dev/cpuset/foreground/boost/cpus 0-3
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/system-background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/top-app/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/boost/cpus
 ##############################################################
 # Source: device/intel/mixins/groups/rfkill/true/init.rc
 ##############################################################

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -23,7 +23,7 @@ boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_tim
 audio: project-celadon
 wlan: iwlwifi
 cpu-arch: skl
-cpuset: 4cores
+cpuset: autocores
 rfkill: true(force_disable=)
 dexpreopt: enabled
 disk-bus: auto


### PR DESCRIPTION
Change cpuset configuration from hard-coded into configure dynamically,
then cpuset feature can work on other hardware platform with different
cpu core numbers.

Jira: https://01.org/jira/browse/CEL-3
Test: Test it in UP2 board.

Signed-off-by: Chen Lin Z <lin.z.chen@intel.com>