### PR TITLE
Set ignore_not_applicable_reset to true

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -19,7 +19,7 @@ usb-gadget: g_ffs
 adb_net: true
 kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
 bluetooth: btusb (ivi=true)
-boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true)
+boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true)
 audio: project-celadon
 wlan: iwlwifi
 cpu-arch: skl

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -19,7 +19,7 @@ usb-gadget: g_ffs
 adb_net: true
 kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
 bluetooth: btusb
-boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true)
+boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true)
 audio: project-celadon
 wlan: iwlwifi
 cpu-arch: skl


### PR DESCRIPTION
Setting this flag to true makes the bootloader ignore the
not_applicable boot reason.

Jira: None.
Test: When this feature is enabled the boot reason will be
      something other than not_applicable.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>