### PR TITLE
Add Support to enable ADB over DBC

### DIFF
--- a/sepolicy/usb-gadget/adbd.te
+++ b/sepolicy/usb-gadget/adbd.te
@@ -1,0 +1,2 @@
+allow adbd dbc_device:chr_file rw_file_perms;
+allow adbd dbc_device:chr_file ioctl;

--- a/sepolicy/usb-gadget/device.te
+++ b/sepolicy/usb-gadget/device.te
@@ -1,0 +1,1 @@
+type dbc_device, dev_type;

--- a/sepolicy/usb-gadget/file_contexts
+++ b/sepolicy/usb-gadget/file_contexts
@@ -1,0 +1,1 @@
+/dev/dbc_raw	u:object_r:dbc_device:s0

--- a/sepolicy/usb-gadget/init.te
+++ b/sepolicy/usb-gadget/init.te
@@ -1,0 +1,2 @@
+allow init dbc_device:chr_file rw_file_perms;
+allow init dbc_device:chr_file ioctl;


### PR DESCRIPTION
This patch adds sepolicy changes required to enable adb
over debug-capability provided by xhci.

ADB over DBC can be a useful feature for debug purposes
especially on platforms which lack usb device mode port.

Jira: None
Test: None

Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
Signed-off-by: K, Gururaj <gururaj.k@intel.com>