### PR TITLE
Move the round icon config into tablet config.

### DIFF
--- a/common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -82,8 +82,6 @@
     -->
     <bool name="config_enableWifiDisplay">true</bool>
 
-    <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
-    <bool name="config_useRoundIcon">true</bool>
     <string-array translatable="false" name="config_globalActionsList">
         <item>power</item>
         <item>restart</item>


### PR DESCRIPTION
This config is not suitable for IVI.
Move it to tablet config.

Jira: OAM-65700
Test: Run the cases in OAM-65700
Signed-off-by: Yan, Walter <walterx.yan@intel.com>