### PR TITLE
SELinux: grant app map permission for app_fuse_file

### DIFF
--- a/sepolicy/graphics/project-celadon/appdomain.te
+++ b/sepolicy/graphics/project-celadon/appdomain.te
@@ -4,3 +4,4 @@ allow appdomain hal_graphics_allocator_default_tmpfs:file { read write map };
 allow appdomain hal_graphics_composer_default_tmpfs:file { read write map };
 allow appdomain gpu_device:dir r_dir_perms;
 allow appdomain sysfs_app_readable:file r_file_perms;
+allow appdomain app_fuse_file:file map;


### PR DESCRIPTION
This is used to resolve the issue that images on other
android devices in MTP initiator role cannot be opened.

Jira: None.
Test: images on other android devices in MTP initiator
role can be opened.

Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>