### PR TITLE
Set ivi flag true for car(cel_apl)

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -18,7 +18,7 @@ display-density: default
 usb-gadget: g_ffs
 adb_net: true
 kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
-bluetooth: btusb
+bluetooth: btusb (ivi=true)
 boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true)
 audio: project-celadon
 wlan: iwlwifi


### PR DESCRIPTION
Description:
- Need to maintain seperate bluetooth configuration header
  file (bdroid_buildcfg.h) based on device (car or tablet)
- To decide device-type at compile time, used one flag
  "ivi" with default value "false" and it will be "true"
  only in case of device type "car".
- To make its value "true" for car, set its value to "true"
  in mixins.spec present under cel_apl.

Jira: https://jira01.devtools.intel.com/browse/OAM-65576

Test:
- For cel_apl build,it should refer to bluetooth header file
  selected for car - PASS
- BT AVRCP should work, user shouble be able to control music
  from Bluetooth Audio App on kabylake IVI - PASS

Signed-off-by: Umesh Agarwal <umeshx.agarwal@intel.com>