### PR TITLE
Enable the support of build the whole gpt image, used for USB live boot.

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -48,3 +48,4 @@ memtrack: true
 touch: galax7200
 avb: true
 slot-ab: true
+gptbuild: true(size=14G)

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -48,3 +48,4 @@ memtrack: true
 touch: galax7200
 avb: true
 slot-ab: true
+gptbuild: true(size=14G)


### PR DESCRIPTION
Use the command 'make SPARSE_IMG=true
KERNELFLINGER_SUPPORT_USB_STORAGE=true gptimage' to build a USB live boot
image.
The gernerated image is out/target/product/celadon/celadon.img.
Flash it to a USB disk, then can boot form this USB disk to Android
directly without install.

Jira: https://01.org/jira/projects/CEL/issues/CEL-13
Test: Test it in KBL NUC.
      Build a USB live boot image. And can use it to boot to Android.

Signed-off-by: Ming Tan <ming.tan@intel.com>