### PR TITLE
Summary: - Enable pstore to save kernel panic log

### DIFF
--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -33,6 +33,7 @@ thermal: dptf(intel_modem=true)
 config-partition: enabled
 vendor-partition: true
 factory-partition: true
+pstore: ram_dummy(address=0x50000000,size=0x400000,record_size=0x4000,console_size=0x200000,ftrace_size=0x2000,dump_oops=1)
 debug-crashlogd: true
 debug-logs: true
 debug-coredump: true


### PR DESCRIPTION
Description:
- Specify ramoops.mem_address=0x50000000 and ramoops.mem_size
  =0x400000 to save kernel panic log.

Jira: https://jira01.devtools.intel.com/browse/OAM-66587

Test:
- use "echo c > /proc/sysrq-trigger" to trigger a kernel panic
- use "cat /data/logs/history_event" to check whether a IPANIC_FAKE
  event generated in hiatory_event file. console-ramoops-xxxxxxxxx
  involve kernel panic log and it is in the directory behind the
  IPANIC_FAKE event name.

Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>