### PR TITLE
Fix the error when use PFT in Joule.

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -38,7 +38,7 @@ debug-logs: true
 debug-coredump: true
 debug-phonedoctor: true
 debug-tools: true
-flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=3500,installer=true)
+flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true)
 midi: true
 trusty: true(ref_target=project-celadon_64)
 slcan: default

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -38,7 +38,7 @@ debug-logs: true
 debug-coredump: true
 debug-phonedoctor: true
 debug-tools: true
-flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=3500,installer=true)
+flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true)
 midi: true
 trusty: true(ref_target=project-celadon_64)
 slcan: default


### PR DESCRIPTION
Set the fastboot_min_battery_level = false in mixins.spec.
The old code set fastboot_min_battery_level=3500, but the Joule and NUC
do not support battery.

Jira: https://01.org/jira/browse/CEL-29
Test: Test it in Joule, can use PFT now.
      Since KBL NUC does not support PFT now, need not to test it.

Signed-off-by: Ming Tan <ming.tan@intel.com>