### PR TITLE
Audio: Add sepolicy files

### DIFF
--- a/sepolicy/audio/project-celadon/audioserver.te
+++ b/sepolicy/audio/project-celadon/audioserver.te
@@ -1,1 +1,26 @@
 ignore_adb_debug(audioserver)
+
+set_prop(audioserver, audio_prop)
+
+userdebug_or_eng(`
+  # audioserver exposes a remote debugging port
+
+  # used for parameter framework (PFW) tuning and debug
+  dontaudit audioserver fwmarkd_socket:sock_file write;
+  dontaudit audioserver netd:unix_stream_socket connectto;
+  dontaudit audioserver node:tcp_socket node_bind;
+  dontaudit audioserver port:tcp_socket name_bind;
+  dontaudit audioserver self:tcp_socket { accept bind create getopt listen read setopt write };
+')
+
+# audioserver recovery mechanism through uevent
+allow audioserver self:netlink_kobject_uevent_socket { create bind setopt read };
+allowxperm audioserver self:netlink_kobject_uevent_socket ioctl SIOCETHTOOL;
+
+# Ringbuffer data files & Runtime Communication with SmartXBar data files
+allow audioserver audioserver_data_file:dir rw_dir_perms;
+allow audioserver audioserver_data_file:{ file fifo_file } create_file_perms;
+
+# allow audioserver to set SCHED_FIFO for SmartXBar worker threads
+allow audioserver self:capability sys_nice;
+allow audioserver self:process { setsched };

--- a/sepolicy/audio/project-celadon/file_contexts
+++ b/sepolicy/audio/project-celadon/file_contexts
@@ -1,0 +1,1 @@
+/dev/snd/.*                 u:object_r:audio_device:s0

--- a/sepolicy/audio/project-celadon/hal_audio_default.te
+++ b/sepolicy/audio/project-celadon/hal_audio_default.te
@@ -1,3 +1,15 @@
+#
+# hal_audio_default is provided by the base policy and mixin
+# project-celadon defines the hal services.
+#
+# Audio uses the default implementations as defined in the product.mk:
+# audio/project-celadon/product.mk:    android.hardware.audio@2.0-impl \
+# audio/project-celadon/product.mk:    android.hardware.audio@2.0-service \
+# audio/project-celadon/product.mk:    android.hardware.audio.effect@2.0-impl \
+#
+# Which can be found digging around: hardware/interfaces/audio/2.0
+#
+
 ignore_adb_debug(hal_audio_default)
 
 allow hal_audio_default self:capability sys_nice;

--- a/sepolicy/audio/project-celadon/netd.te
+++ b/sepolicy/audio/project-celadon/netd.te
@@ -1,0 +1,7 @@
+userdebug_or_eng(`
+  # used for parameter framework (PFW) tuning and debug
+  allow netd hal_audio_default:fd use;
+  allow netd hal_audio_default:tcp_socket { getopt read setopt write };
+  allow netd audioserver:fd use;
+  allow netd audioserver:tcp_socket { getopt read setopt write };
+')

--- a/sepolicy/audio/project-celadon/property.te
+++ b/sepolicy/audio/project-celadon/property.te
@@ -1,0 +1,1 @@
+type audiohal_prop, property_type;

--- a/sepolicy/audio/project-celadon/property_contexts
+++ b/sepolicy/audio/project-celadon/property_contexts
@@ -1,0 +1,2 @@
+audiohal.            u:object_r:audiohal_prop:s0
+persist.audiohal.    u:object_r:audiohal_prop:s0

--- a/sepolicy/audio/project-celadon/system_server.te
+++ b/sepolicy/audio/project-celadon/system_server.te
@@ -1,0 +1,6 @@
+#
+# system_server
+#
+
+allow system_server hal_audio_default:file write;
+allow system_server audioserver:file w_file_perms;

--- a/sepolicy/audio/project-celadon/violators_blacklist.te
+++ b/sepolicy/audio/project-celadon/violators_blacklist.te
@@ -1,0 +1,1 @@
+typeattribute hal_audio_default data_between_core_and_vendor_violators;


### PR DESCRIPTION
Due to missing sepolicies for audio, audio server is getting
restarted and as a result bluetooth service also gets restarted.

Add sepolicies for audio to get audio and bluetooth working.

Tracked-On: OAM-67968

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Signed-off-by: Ding XinX <xinx.ding@intel.com>
Signed-off-by: Qiming Shi <qiming.shi@intel.com>