### PR TITLE
Adding stable firmware for 8265 & 3168 modules.

### DIFF
--- a/common/firmware.mk
+++ b/common/firmware.mk
@@ -19,7 +19,9 @@
 LOCAL_FIRMWARE_SRC := \
     i6050-fw-usb-1.5.sbcf \
     i2400m-fw-usb-1.4.sbcf \
-    i2400m-fw-usb-1.5.sbcf
+    i2400m-fw-usb-1.5.sbcf \
+    iwlwifi-3168-29.ucode \
+    iwlwifi-8265-31.ucode
 
 ## List of complete Firmware folders to be copied
 
@@ -29,8 +31,8 @@ LOCAL_FIRMWARE_DIR := \
 
 ## List of matching patterns of Firmware bins to be copied
 
-LOCAL_FIRMWARE_PATTERN := \
-    iwlwifi
+#LOCAL_FIRMWARE_PATTERN := \
+#    iwlwifi
 
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN),$(shell cd $(FIRMWARES_DIR) && find . -iname "*$(f)*" -type f ))
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_DIR),$(shell cd $(FIRMWARES_DIR) && find $(f) -type f) )


### PR DESCRIPTION
Hidden SSID in 5Ghz fails with the latest upstreamed firmware,
hence modified to pick stable firmware instead upstreamed one.

Changes
- Modified firmware.mk to pick the stable firmware.
- Removed FIRMWARE_PATTERN macro, which adds non device specific
  firmwares as well.

Tracked-On: OAM-66721
Signed-off-by: Babu Chennakesavulu, Raveendra
			<raveendra.babu.chennakesavulu@intel.com>