### PR TITLE
Debug:pstore: Disable pstore to support grub

### DIFF
--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -33,7 +33,6 @@ thermal: dptf(intel_modem=true)
 config-partition: enabled
 vendor-partition: true
 factory-partition: true
-pstore: ram_dummy(address=0x50000000,size=0x400000,record_size=0x4000,console_size=0x200000,ftrace_size=0x2000,dump_oops=1)
 debug-crashlogd: true
 debug-logs: true
 debug-coredump: true


### PR DESCRIPTION
Delete pstore from mixin spec file to make OS can be
booted normally by grub.
Jira: https://jira01.devtools.intel.com/browse/OAM-68216
Test: Test it on celadon.
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>
Signed-off-by: Tian, Baofeng <baofeng.tian@intel.com>