### PR TITLE
[MIXINUP] enable socperf and socwatch driver

### DIFF
--- a/cel_apl/AndroidBoard.mk
+++ b/cel_apl/AndroidBoard.mk
@@ -69,7 +69,8 @@ $(PRODUCT_OUT)/kernel: $(KERNEL_CONFIG) | $(ACP)
 	$(hide) $(ACP) -fp $(KERNEL_BIN) $@
 
 EXTMOD_SRC := ../../../../../..
-TARGET_EXTRA_KERNEL_MODULES :=
+TARGET_EXTRA_KERNEL_MODULES := $(EXTMOD_SRC)/kernel/modules/perftools-external/soc_perf_driver/src
+TARGET_EXTRA_KERNEL_MODULES += $(EXTMOD_SRC)/kernel/modules/perftools-external/socwatch_driver
 
 ALL_EXTRA_MODULES := $(patsubst %,$(TARGET_OUT_INTERMEDIATES)/kmodule/%,$(TARGET_EXTRA_KERNEL_MODULES))
 $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kernel
@@ -82,7 +83,7 @@ $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kern
 $(KERNEL_MODULES_INSTALL): $(PRODUCT_OUT)/kernel $(ALL_EXTRA_MODULES)
 	$(hide) rm -rf $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules
 	$(build_kernel) modules_install
-	$(hide) for kmod in "$(TARGET_EXTRA_KERNEL_MODULES)" ; do \
+	$(hide) for kmod in $(TARGET_EXTRA_KERNEL_MODULES) ; do \
 		echo Installing additional kernel module $${kmod} ; \
 		$(subst +,,$(subst $(hide),,$(build_kernel))) M=$(abspath $(TARGET_OUT_INTERMEDIATES))/kernel/$${kmod} modules_install ; \
 	done

--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -17,7 +17,7 @@ storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=false)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true
-kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
+kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true, external_modules=perftools-external/soc_perf_driver/src perftools-external/socwatch_driver)
 bluetooth: btusb (ivi=true)
 boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true)
 audio: project-celadon

--- a/celadon/AndroidBoard.mk
+++ b/celadon/AndroidBoard.mk
@@ -63,7 +63,8 @@ $(PRODUCT_OUT)/kernel: $(KERNEL_CONFIG) | $(ACP)
 	$(hide) $(ACP) -fp $(KERNEL_BIN) $@
 
 EXTMOD_SRC := ../../../../../..
-TARGET_EXTRA_KERNEL_MODULES :=
+TARGET_EXTRA_KERNEL_MODULES := $(EXTMOD_SRC)/kernel/modules/perftools-external/soc_perf_driver/src
+TARGET_EXTRA_KERNEL_MODULES += $(EXTMOD_SRC)/kernel/modules/perftools-external/socwatch_driver
 
 ALL_EXTRA_MODULES := $(patsubst %,$(TARGET_OUT_INTERMEDIATES)/kmodule/%,$(TARGET_EXTRA_KERNEL_MODULES))
 $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kernel
@@ -76,7 +77,7 @@ $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kern
 $(KERNEL_MODULES_INSTALL): $(PRODUCT_OUT)/kernel $(ALL_EXTRA_MODULES)
 	$(hide) rm -rf $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules
 	$(build_kernel) modules_install
-	$(hide) for kmod in "$(TARGET_EXTRA_KERNEL_MODULES)" ; do \
+	$(hide) for kmod in $(TARGET_EXTRA_KERNEL_MODULES) ; do \
 		echo Installing additional kernel module $${kmod} ; \
 		$(subst +,,$(subst $(hide),,$(build_kernel))) M=$(abspath $(TARGET_OUT_INTERMEDIATES))/kernel/$${kmod} modules_install ; \
 	done

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -17,7 +17,7 @@ storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=false)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true
-kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
+kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true, external_modules=perftools-external/soc_perf_driver/src perftools-external/socwatch_driver)
 bluetooth: btusb
 boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true)
 audio: project-celadon


### PR DESCRIPTION
It adds socperf and socwatch kernel-module in extra kernel modules
to consider extra modules for compile and build.

Tracked-On: None