### PR TITLE
Mixin: Enable USB camera as External Camera

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -44,7 +44,7 @@ midi: true
 trusty: true(enable_hw_sec=true,enable_storage_proxyd=true,ref_target=project-celadon_64)
 slcan: default
 ioc-slcan-reboot: false
-camera: usbcamera
+camera-ext: ext-camera-only
 memtrack: true
 touch: galax7200
 avb: true

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -44,7 +44,7 @@ midi: true
 trusty: true(enable_hw_sec=true,enable_storage_proxyd=true,ref_target=project-celadon_64)
 slcan: default
 ioc-slcan-reboot: false
-camera: usbcamera
+camera-ext: ext-camera-only
 memtrack: true
 touch: galax7200
 avb: true


### PR DESCRIPTION
Enable USB camera as external camera for
both cel_apl and celadon targets. This
option is newly introduced on Android P

Tracked-On: None

Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>