### PR TITLE
[Celadon] Remove hevc encoder library

### DIFF
--- a/cel_apl/device.mk
+++ b/cel_apl/device.mk
@@ -251,8 +251,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PACKAGES += \
     libmfxhw32 \
     libmfxhw64 \
-    libmfx_hevce_hw32 \
-    libmfx_hevce_hw64 \
     libmfx_omx_core \
     libmfx_omx_components_hw \
     libstagefrighthw

--- a/celadon/device.mk
+++ b/celadon/device.mk
@@ -240,8 +240,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PACKAGES += \
     libmfxhw32 \
     libmfxhw64 \
-    libmfx_hevce_hw32 \
-    libmfx_hevce_hw64 \
     libmfx_omx_core \
     libmfx_omx_components_hw \
     libstagefrighthw


### PR DESCRIPTION
Remove hevc encoder library as hevc encoder is already supported in libmfxhw64.

Jira: None.
Test: None.

Signed-off-by: tianmi.chen <tianmi.chen@intel.com>