### PR TITLE
[CELADON] Fix the issue that kitchensink_app cannot send bluetooth msg

### DIFF
--- a/sepolicy/car/kitchensink_app.te
+++ b/sepolicy/car/kitchensink_app.te
@@ -1,0 +1,3 @@
+userdebug_or_eng(`
+  allow kitchensink_app { textservices_service bluetooth_manager_service }:service_manager find;
+')


### PR DESCRIPTION
This issue relates with the AOSP Car service module, It'd better
put these rules to packages/services/Car/car_product/sepolicy/test.
Maybe we need to upstream this patch?

Tracked-On: OAM-68589
Signed-off-by: Swaroop Balan <swaroop.balan@intel.com>