### PR TITLE
Fix for changing the order of updating the flags for

### DIFF
--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -10,7 +10,6 @@ project-celadon: default
 sepolicy: permissive
 graphics: project-celadon(gen9+=true,hwc2=true,vulkan=false,drmhwc=false,minigbm=true,gralloc1=true)
 media: project-celadon(mediasdk=false,media_sdk_source=false)
-device-type: tablet
 ethernet: dhcp
 debugfs: default
 storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=false)
@@ -51,3 +50,4 @@ avb: true
 slot-ab: true
 art-config: default
 gptbuild: true(size=14G)
+device-type: tablet


### PR DESCRIPTION
celadon TABLET

Description:
We see that the flags for device type car is overriding
the flags defined for overlay-tablet.Since we are
referring to the flags of overlay-tablet for
celadon TABLET, changed the order to update the
overlay-tablet first in mixins.spec

Tracked-On: OAM-67866

Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>