### PR TITLE
[MIXINUP] USB live boot image should set bootloader2 partition empty.

### DIFF
--- a/cel_apl/AndroidBoard.mk
+++ b/cel_apl/AndroidBoard.mk
@@ -545,7 +545,6 @@ $(GPTIMAGE_BIN): \
 		--table $(TARGET_DEVICE_DIR)/gpt.ini \
 		--size $(gptimage_size) \
 		--bootloader $(bootloader_bin) \
-		--bootloader2 $(bootloader_bin) \
 		--tos $(tos_bin) \
 		--multiboot $(multiboot_bin) \
 		--boot $(INSTALLED_BOOTIMAGE_TARGET) \

--- a/celadon/AndroidBoard.mk
+++ b/celadon/AndroidBoard.mk
@@ -545,7 +545,6 @@ $(GPTIMAGE_BIN): \
 		--table $(TARGET_DEVICE_DIR)/gpt.ini \
 		--size $(gptimage_size) \
 		--bootloader $(bootloader_bin) \
-		--bootloader2 $(bootloader_bin) \
 		--tos $(tos_bin) \
 		--multiboot $(multiboot_bin) \
 		--boot $(INSTALLED_BOOTIMAGE_TARGET) \


### PR DESCRIPTION
[MIXINUP] USB live boot image should set bootloader2 partition empty.

Tracked-On: OAM-69453

Signed-off-by: Meng, KangX <kangx.meng@intel.com>