### PR TITLE
support adoptable storage on usb

### DIFF
--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -13,7 +13,7 @@ media: project-celadon(mediasdk=false,media_sdk_source=false)
 device-type: tablet
 ethernet: dhcp
 debugfs: default
-storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=false)
+storage: sdcard-mmc0-usb-sd(adoptablesd=false,adoptableusb=true)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true


### PR DESCRIPTION
since there is no sd card slot on Commercial KBL-NUC, use adoptable usb to test related function instead.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-69262
Signed-off-by: Zhiwei li zhiwei.li@intel.com