### PR TITLE
Debug: remove logd.te file

### DIFF
--- a/sepolicy/logd.te
+++ b/sepolicy/logd.te
@@ -1,1 +1,0 @@
-allow logd logd:capability dac_override;


### PR DESCRIPTION
Because logd is not in whitelist of acquiring dac_override permission. remove logd dac_override permission for itself to fix SELinuxNeverallowRulesTest error in CtsSecurityHostTestCases Module.

Jira: https://jira01.devtools.intel.com/browse/OAM-71343
Test: None
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>