### PR TITLE
Sepolicy: add set_storage to coredomain.

### DIFF
--- a/sepolicy/set_storage/set_storage.te
+++ b/sepolicy/set_storage/set_storage.te
@@ -2,7 +2,7 @@
 # set_storage - set symlink on /dev/block/by-name
 #
 
-type set_storage, domain;
+type set_storage, domain, coredomain;
 
 allow set_storage self:capability { fsetid };
 


### PR DESCRIPTION
The old code will cause CTS report following error:
junit.framework.AssertionFailedError: The following domain(s) must be
associated with the "coredomain" attribute because they are executed off
of /system:
This patch will add set_storage to codedomain.
After enable the treble, will move the set_storage to /vendor/bin.

Jira: OAM-71287
Test: Pass the CtsSecurityHostTestCases testing case.

Signed-off-by: Ming Tan <ming.tan@intel.com>