### PR TITLE
Configurate the multi-window and split screen

### DIFF
--- a/common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -89,4 +89,10 @@
         <item>bugreport</item>
         <item>users</item>
     </string-array>
+
+    <!-- Required to enable activity on secondary display -->
+    <bool name="config_supportsMultiWindow">true</bool>
+    <!-- Don't support split screen multiwindow -->
+    <bool name="config_supportsSplitScreenMultiWindow">false</bool>
+
 </resources>


### PR DESCRIPTION
1. Enable activity on secondary display
2. Disable supports split screen multi-window

Tracked-On: OAM-71353
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>