### PR TITLE
[MIXINUP] Add car product overlays

### DIFF
--- a/cel_apl/device.mk
+++ b/cel_apl/device.mk
@@ -710,6 +710,9 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.broadcastradio.xml:vendor/etc/permissions/android.hardware.broadcastradio.xml \
     frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:vendor/etc/permissions/android.software.activities_on_secondary_displays.xml
 
+# Make sure vendor car product overlays take precedence than google definition
+# under packages/services/Car/car_product/overlay/
+PRODUCT_PACKAGE_OVERLAYS += device/intel/common/device-type/overlay-car
 $(call inherit-product, packages/services/Car/car_product/build/car.mk)
 
 $(call inherit-product,frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)


### PR DESCRIPTION
Google car.mk will define PRODUCT_PACKAGE_OVERLAYS, we need to make sure
vendor car product overlays take precedence than google definition under
packages/service/Car/car_product/overlay for customization.

Tracked-On: OAM-71506
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>