### PR TITLE
[MIXINUP] Fix cts failure in CtsAppTestCases

### DIFF
--- a/cel_apl/device.mk
+++ b/cel_apl/device.mk
@@ -714,7 +714,8 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.screen.landscape.xml:vendor/etc/permissions/android.hardware.screen.landscape.xml \
     frameworks/native/data/etc/android.hardware.ethernet.xml:vendor/etc/permissions/android.hardware.ethernet.xml \
     frameworks/native/data/etc/android.hardware.broadcastradio.xml:vendor/etc/permissions/android.hardware.broadcastradio.xml \
-    frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:vendor/etc/permissions/android.software.activities_on_secondary_displays.xml
+    frameworks/native/data/etc/android.software.activities_on_secondary_displays.xml:vendor/etc/permissions/android.software.activities_on_secondary_displays.xml \
+    $(INTEL_PATH_COMMON)/framework/android.software.cant_save_state.xml:vendor/etc/permissions/android.software.cant_save_state.xml
 
 # Make sure vendor car product overlays take precedence than google definition
 # under packages/services/Car/car_product/overlay/


### PR DESCRIPTION
CTS failure due to don't support feature: FEATURE_CANT_SAVE_STATE
the feature is for supporting the R.attr.cantSaveState API( sdk28),
the cantSaveState declare that this application can't participate
in the normal state save/restore mechanism.

Test: run cts -m CtsAppTestCases \
        -t
android.app.cts.ActivityManagerProcessStateTest#testCantSaveStateLaunchAndBackground
      run cts -m CtsAppTestCases \
        -t
android.app.cts.ActivityManagerProcessStateTest#testCantSaveStateLaunchAndSwitch

Tracked-On: OAM-71298
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>