### PR TITLE
Fix the neverallow violations

### DIFF
--- a/sepolicy/domain.te
+++ b/sepolicy/domain.te
@@ -1,2 +1,0 @@
-allow domain sysfs_socinfo:dir r_dir_perms;
-allow domain sysfs_socinfo:file r_file_perms;

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -5,5 +5,4 @@ type sysfs_thermal_writable, fs_type, sysfs_type;
 type atvr_device, dev_type;
 type sysfs_coretemp, fs_type, sysfs_type;
 type gpu_pid_stats_file, fs_type, debugfs_type;
-type sysfs_socinfo, sysfs_type, fs_type;
 type debugfs_pstate, fs_type, debugfs_type;

--- a/sepolicy/graphics/project-celadon/appdomain.te
+++ b/sepolicy/graphics/project-celadon/appdomain.te
@@ -3,5 +3,5 @@
 allow appdomain hal_graphics_allocator_default_tmpfs:file { read write map };
 allow appdomain hal_graphics_composer_default_tmpfs:file { read write map };
 allow appdomain gpu_device:dir r_dir_perms;
-allow appdomain sysfs_app_readable:file r_file_perms;
+allow { appdomain -isolated_app } sysfs_app_readable:file r_file_perms;
 allow appdomain app_fuse_file:file map;

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -14,13 +14,11 @@ allow init tmpfs:lnk_file create_file_perms;
 # set attributes on /sys/class/gpio sym link
 # chmod 0770 /sys/class/gpio/gpio66
 allow init sysfs:lnk_file setattr;
-allow init sysfs:dir { write add_name };
 # userspace cannot create files in sys. ignore denial
 dontaudit init sysfs_devices_system_cpu:dir write;
 allow init { cache_file storage_file }:dir mounton;
 # /config
 allow init configfs:{ file lnk_file } create_file_perms;
-allow init cgroup:file create;
 allow init sw_sync_device:file { relabelto setattr read write open ioctl };
 allow init sysfs:file create;
 allow init devpts:chr_file { ioctl };

--- a/sepolicy/kernel/appdomain.te
+++ b/sepolicy/kernel/appdomain.te
@@ -1,2 +1,1 @@
-allow appdomain proc_version:file r_file_perms;
 allow appdomain self:icmp_socket create_socket_perms_no_ioctl;

--- a/sepolicy/kernel/domain.te
+++ b/sepolicy/kernel/domain.te
@@ -1,0 +1,22 @@
+dontaudit {
+	dnsmasq
+	dumpstate
+	init
+	installd
+	install_recovery
+	lmkd
+	netd
+	perfprofd
+	postinstall_dexopt
+	recovery
+	sdcardd
+	tee
+	ueventd
+	uncrypt
+	vendor_init
+	vold
+	vold_prepare_subdirs
+	zygote
+} self:capability dac_read_search;
+
+allow domain vendor_configs_file:file map;

--- a/sepolicy/kernel/init.te
+++ b/sepolicy/kernel/init.te
@@ -6,11 +6,10 @@ allow init {
   vendor_file
 }:system module_load;
 
-allow init sysfs_devices_system_cpu:dir rw_dir_perms;
+allow init sysfs_devices_system_cpu:dir r_dir_perms;
 allow init sysfs_devices_system_cpu:file create_file_perms;
 allow init tmpfs:lnk_file create_file_perms;
 allow init configfs:{ file lnk_file } create_file_perms;
-allow init self:capability dac_read_search;
 allow init self:capability sys_module;
 allow init self:capability2 block_suspend;
 

--- a/sepolicy/kernel/installd.te
+++ b/sepolicy/kernel/installd.te
@@ -1,1 +1,0 @@
-allow installd self:capability dac_read_search;

--- a/sepolicy/kernel/system_server.te
+++ b/sepolicy/kernel/system_server.te
@@ -2,8 +2,6 @@
 # system_server
 #
 
-allow system_server proc_version:file r_file_perms;
-
 allow system_server audioserver:file rw_file_perms;
 allow system_server system_app:file rw_file_perms;
 

--- a/sepolicy/kernel/vold.te
+++ b/sepolicy/kernel/vold.te
@@ -1,1 +1,0 @@
-allow vold self:capability dac_read_search;

--- a/sepolicy/kernel/zygote.te
+++ b/sepolicy/kernel/zygote.te
@@ -1,1 +1,0 @@
-allow zygote self:capability dac_read_search;


### PR DESCRIPTION
There are lots of neverallow violations during the cts
test, we need to remove the related rules.

Tracked-On: OAM-71989
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>