### PR TITLE
Set config_enableWifiDisplay to false

### DIFF
--- a/common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -80,7 +80,7 @@
          * The remote submix module "audio.r_submix.default" must be installed on the device.
          * The device must be provisioned with HDCP keys (for protected content).
     -->
-    <bool name="config_enableWifiDisplay">true</bool>
+    <bool name="config_enableWifiDisplay">false</bool>
 
     <string-array translatable="false" name="config_globalActionsList">
         <item>power</item>


### PR DESCRIPTION
Wifi Direct will work when wifi vendor hal is supported.
Intel doesnot have wifi vendor hal implementation,
Hence to pass Concurrencytest, wifi direct is disabled.

Tracked-On: OAM-71339
Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>