### PR TITLE
Remove sepolicy rule for dumpstate_dropbox

### DIFF
--- a/sepolicy/crashlogd/dumpstate_dropbox.te
+++ b/sepolicy/crashlogd/dumpstate_dropbox.te
@@ -6,7 +6,7 @@ userdebug_or_eng(`
 
   permissive dumpstate_dropbox;
 
-  allow dumpstate_dropbox self:capability { chown dac_override };
+  dontaudit dumpstate_dropbox self:capability { chown dac_override };
   allow dumpstate_dropbox system_server:binder call;
 
   allow domain dumpstate_dropbox:fd use;


### PR DESCRIPTION
Remove bellow rule for dumpstate_dropbox to fix cts test errors:
allow dumpstate_dropbox self:capability { chown dac_override };

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71987
Signed-off-by: Xinanx, Luo <xinanx.luo@intel.com>