### PR TITLE
Remove sepolicy rules for logsvc

### DIFF
--- a/sepolicy/debug-logs/logsvc.te
+++ b/sepolicy/debug-logs/logsvc.te
@@ -4,10 +4,12 @@ type logsvc_exec, exec_type, file_type;
 
 init_daemon_domain(logsvc);
 
+permissive logsvc;
+
 allow logsvc system_file:file x_file_perms;
 allow logsvc shell_exec:file rx_file_perms;
 
-allow logsvc self:capability { dac_override sys_nice };
+dontaudit logsvc self:capability { dac_override sys_nice };
 allow logsvc self:capability2 syslog;
 
 allow logsvc log_file:file create_file_perms;


### PR DESCRIPTION
Remove bellow rule for logsvc to fix cts test errors:
allow logsvc self:capability { dac_override sys_nice };

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71987
Signed-off-by: Xinanx, Luo xinanx.luo@intel.com