### PR TITLE
Health-HAL: Adding health hal for celadon

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -47,6 +47,7 @@ camera-ext: ext-camera-only
 memtrack: true
 touch: galax7200
 avb: true
+health: true
 slot-ab: true
 art-config: default
 gptbuild: true(size=14G)

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -48,6 +48,7 @@ camera-ext: ext-camera-only
 memtrack: true
 touch: galax7200
 avb: true
+health: true
 slot-ab: true
 art-config: default
 gptbuild: true(size=14G)

--- a/health/Android.bp
+++ b/health/Android.bp
@@ -1,0 +1,93 @@
+cc_library_static {
+    name: "android.hardware.health@2.0-impl.celadon",
+    vendor_available: true,
+    defaults: ["hidl_defaults"],
+    srcs: [
+        "Health.cpp",
+        "healthd_common.cpp",
+    ],
+
+    cflags: ["-DHEALTHD_USE_HEALTH_2_0"],
+
+
+    shared_libs: [
+        "libbase",
+        "libhidlbase",
+        "libhidltransport",
+        "libhwbinder",
+        "liblog",
+        "libutils",
+        "libcutils",
+        "android.hardware.health@2.0",
+    ],
+
+    export_include_dirs: ["include"],
+
+    static_libs: [
+        "libbatterymonitor",
+        "android.hardware.health@1.0-convert",
+    ],
+}
+
+cc_library_static {
+    name: "libhealthservice.celadon",
+    vendor_available: true,
+    srcs: ["HealthServiceCommon.cpp"],
+
+
+    cflags: [
+        "-Wall",
+        "-Werror",
+    ],
+    shared_libs: [
+        "android.hardware.health@2.0",
+    ],
+    static_libs: [
+        "android.hardware.health@2.0-impl.celadon",
+        "android.hardware.health@1.0-convert",
+    ],
+    export_static_lib_headers: [
+        "android.hardware.health@1.0-convert",
+    ],
+    export_include_dirs: ["include"],
+    header_libs: ["libhealthd_headers"],
+    export_header_lib_headers: ["libhealthd_headers"],
+}
+
+
+cc_binary {
+	      name: "android.hardware.health@2.0-service.celadon",
+	      overrides: ["healthd"],
+	      init_rc: ["android.hardware.health@2.0-service.celadon.rc"],
+	      proprietary: true,
+	      relative_install_path: "hw",
+	      srcs: [
+		      "HealthService.cpp",
+	      ],
+
+	      cflags: [
+		      "-Wall",
+		      "-Werror",
+	      ],
+
+	      static_libs: [
+		      "android.hardware.health@1.0-convert",
+		      "android.hardware.health@2.0-impl.celadon",
+		      "libhealthservice.celadon",
+		      "libbatterymonitor",
+ 		      "libhealthstoragedefault",
+	      ],
+
+	      shared_libs: [
+		      "libbase",
+		      "libcutils",
+		      "libhidlbase",
+		      "libhidltransport",
+		      "libhwbinder",
+		      "libutils",
+		      "android.hardware.health@2.0",
+	      ],
+
+	      header_libs: ["libhealthd_headers"],
+}
+

--- a/health/Health.cpp
+++ b/health/Health.cpp
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define LOG_TAG "android.hardware.health@2.0-impl.celadon"
+#include <android-base/logging.h>
+
+#include <android-base/file.h>
+#include <health2/Health.h>
+#include <health2/powerSupplyType.h>
+
+#include <hal_conversion.h>
+#include <hidl/HidlTransportSupport.h>
+
+extern void healthd_battery_update_internal(bool);
+extern unsigned int platformPowerSupplyType;
+
+namespace android {
+namespace hardware {
+namespace health {
+namespace V2_0 {
+namespace implementation {
+
+sp<Health> Health::instance_;
+Health::Health(struct healthd_config* c) {
+    // TODO(b/69268160): remove when libhealthd is removed.
+    healthd_board_init(c);
+    battery_monitor_ = std::make_unique<BatteryMonitor>();
+    battery_monitor_->init(c);
+}
+
+// Methods from IHealth follow.
+Return<Result> Health::registerCallback(const sp<IHealthInfoCallback>& callback) {
+    if (callback == nullptr) {
+        return Result::SUCCESS;
+    }
+
+    {
+        std::lock_guard<std::mutex> _lock(callbacks_lock_);
+        callbacks_.push_back(callback);
+        // unlock
+    }
+
+    auto linkRet = callback->linkToDeath(this, 0u /* cookie */);
+    if (!linkRet.withDefault(false)) {
+        LOG(WARNING) << __func__ << "Cannot link to death: "
+                     << (linkRet.isOk() ? "linkToDeath returns false" : linkRet.description());
+        // ignore the error
+    }
+
+    return update();
+}
+
+bool Health::unregisterCallbackInternal(const sp<IBase>& callback) {
+    if (callback == nullptr) return false;
+
+    bool removed = false;
+    std::lock_guard<std::mutex> _lock(callbacks_lock_);
+    for (auto it = callbacks_.begin(); it != callbacks_.end();) {
+        if (interfacesEqual(*it, callback)) {
+            it = callbacks_.erase(it);
+            removed = true;
+        } else {
+            ++it;
+        }
+    }
+    (void)callback->unlinkToDeath(this).isOk();  // ignore errors
+    return removed;
+}
+
+Return<Result> Health::unregisterCallback(const sp<IHealthInfoCallback>& callback) {
+    return unregisterCallbackInternal(callback) ? Result::SUCCESS : Result::NOT_FOUND;
+}
+
+template <typename T>
+void getProperty(const std::unique_ptr<BatteryMonitor>& monitor, int id, T defaultValue,
+                 const std::function<void(Result, T)>& callback) {
+    struct BatteryProperty prop;
+    T ret = defaultValue;
+    Result result = Result::SUCCESS;
+    if (platformPowerSupplyType == CONSTANT_POWER)
+	    result = Result::NOT_SUPPORTED;
+    else{
+	    status_t err = monitor->getProperty(static_cast<int>(id), &prop);
+	    if (err != OK) {
+		    LOG(DEBUG) << "getProperty(" << id << ")"
+			    << " fails: (" << err << ") " << strerror(-err);
+	    } else {
+		    ret = static_cast<T>(prop.valueInt64);
+	    }
+	    switch (err) {
+		    case OK:
+			    result = Result::SUCCESS;
+			    break;
+		    case NAME_NOT_FOUND:
+			    result = Result::NOT_SUPPORTED;
+			    break;
+		    default:
+			    result = Result::UNKNOWN;
+			    break;
+	    }
+    }
+    callback(result, static_cast<T>(ret));
+}
+
+Return<void> Health::getChargeCounter(getChargeCounter_cb _hidl_cb) {
+    getProperty<int32_t>(battery_monitor_, BATTERY_PROP_CHARGE_COUNTER, 0, _hidl_cb);
+    return Void();
+}
+
+Return<void> Health::getCurrentNow(getCurrentNow_cb _hidl_cb) {
+    getProperty<int32_t>(battery_monitor_, BATTERY_PROP_CURRENT_NOW, 0, _hidl_cb);
+    return Void();
+}
+
+Return<void> Health::getCurrentAverage(getCurrentAverage_cb _hidl_cb) {
+    getProperty<int32_t>(battery_monitor_, BATTERY_PROP_CURRENT_AVG, 0, _hidl_cb);
+    return Void();
+}
+
+Return<void> Health::getCapacity(getCapacity_cb _hidl_cb) {
+    getProperty<int32_t>(battery_monitor_, BATTERY_PROP_CAPACITY, 0, _hidl_cb);
+    return Void();
+}
+
+Return<void> Health::getEnergyCounter(getEnergyCounter_cb _hidl_cb) {
+    getProperty<int64_t>(battery_monitor_, BATTERY_PROP_ENERGY_COUNTER, 0, _hidl_cb);
+    return Void();
+}
+
+Return<void> Health::getChargeStatus(getChargeStatus_cb _hidl_cb) {
+    getProperty(battery_monitor_, BATTERY_PROP_BATTERY_STATUS, BatteryStatus::UNKNOWN, _hidl_cb);
+    return Void();
+}
+
+Return<Result> Health::update() {
+    if (!healthd_mode_ops || !healthd_mode_ops->battery_update) {
+        LOG(WARNING) << "health@2.0: update: not initialized. "
+                     << "update() should not be called in charger / recovery.";
+        return Result::UNKNOWN;
+    }
+
+    // Retrieve all information and call healthd_mode_ops->battery_update, which calls
+    // notifyListeners.
+    bool chargerOnline = battery_monitor_->update();
+
+    // adjust uevent / wakealarm periods
+    healthd_battery_update_internal(chargerOnline);
+
+    return Result::SUCCESS;
+}
+
+void Health::notifyListeners(HealthInfo* healthInfo) {
+    std::vector<StorageInfo> info;
+    get_storage_info(info);
+
+    std::vector<DiskStats> stats;
+    get_disk_stats(stats);
+
+    int32_t currentAvg = 0;
+
+    struct BatteryProperty prop;
+    status_t ret = battery_monitor_->getProperty(BATTERY_PROP_CURRENT_AVG, &prop);
+    if (ret == OK) {
+        currentAvg = static_cast<int32_t>(prop.valueInt64);
+    }
+
+    healthInfo->batteryCurrentAverage = currentAvg;
+    healthInfo->diskStats = stats;
+    healthInfo->storageInfos = info;
+
+    std::lock_guard<std::mutex> _lock(callbacks_lock_);
+    for (auto it = callbacks_.begin(); it != callbacks_.end();) {
+        auto ret = (*it)->healthInfoChanged(*healthInfo);
+        if (!ret.isOk() && ret.isDeadObject()) {
+            it = callbacks_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+Return<void> Health::debug(const hidl_handle& handle, const hidl_vec<hidl_string>&) {
+    if (handle != nullptr && handle->numFds >= 1) {
+        int fd = handle->data[0];
+        battery_monitor_->dumpState(fd);
+
+        getHealthInfo([fd](auto res, const auto& info) {
+            android::base::WriteStringToFd("\ngetHealthInfo -> ", fd);
+            if (res == Result::SUCCESS) {
+                android::base::WriteStringToFd(toString(info), fd);
+            } else {
+                android::base::WriteStringToFd(toString(res), fd);
+            }
+            android::base::WriteStringToFd("\n", fd);
+        });
+
+        fsync(fd);
+    }
+    return Void();
+}
+
+Return<void> Health::getStorageInfo(getStorageInfo_cb _hidl_cb) {
+    std::vector<struct StorageInfo> info;
+    get_storage_info(info);
+    hidl_vec<struct StorageInfo> info_vec(info);
+    if (!info.size()) {
+        _hidl_cb(Result::NOT_SUPPORTED, info_vec);
+    } else {
+        _hidl_cb(Result::SUCCESS, info_vec);
+    }
+    return Void();
+}
+
+Return<void> Health::getDiskStats(getDiskStats_cb _hidl_cb) {
+    std::vector<struct DiskStats> stats;
+    get_disk_stats(stats);
+    hidl_vec<struct DiskStats> stats_vec(stats);
+    if (!stats.size()) {
+        _hidl_cb(Result::NOT_SUPPORTED, stats_vec);
+    } else {
+        _hidl_cb(Result::SUCCESS, stats_vec);
+    }
+    return Void();
+}
+
+Return<void> Health::getHealthInfo(getHealthInfo_cb _hidl_cb) {
+    using android::hardware::health::V1_0::hal_conversion::convertToHealthInfo;
+    using android::hardware::health::V1_0::BatteryStatus;
+    using android::hardware::health::V1_0::BatteryHealth;
+
+    update();
+    struct android::BatteryProperties p = getBatteryProperties(battery_monitor_.get());
+    V1_0::HealthInfo batteryInfo;
+    convertToHealthInfo(&p, batteryInfo);
+    std::vector<StorageInfo> info;
+    get_storage_info(info);
+
+    std::vector<DiskStats> stats;
+    get_disk_stats(stats);
+
+    int32_t currentAvg = 0;
+
+    struct BatteryProperty prop;
+    status_t ret = battery_monitor_->getProperty(BATTERY_PROP_CURRENT_AVG, &prop);
+    if (ret == OK) {
+        currentAvg = static_cast<int32_t>(prop.valueInt64);
+    }
+
+    V2_0::HealthInfo healthInfo = {};
+    healthInfo.legacy = std::move(batteryInfo);
+    healthInfo.batteryCurrentAverage = currentAvg;
+    healthInfo.diskStats = stats;
+    healthInfo.storageInfos = info;
+
+    _hidl_cb(Result::SUCCESS, healthInfo);
+    return Void();
+}
+
+void Health::serviceDied(uint64_t /* cookie */, const wp<IBase>& who) {
+    (void)unregisterCallbackInternal(who.promote());
+}
+
+sp<IHealth> Health::initInstance(struct healthd_config* c) {
+    if (instance_ == nullptr) {
+        instance_ = new Health(c);
+    }
+    return instance_;
+}
+
+sp<Health> Health::getImplementation() {
+    CHECK(instance_ != nullptr);
+    return instance_;
+}
+
+}  // namespace implementation
+}  // namespace V2_0
+}  // namespace health
+}  // namespace hardware
+}  // namespace android
+

--- a/health/HealthService.cpp
+++ b/health/HealthService.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define LOG_TAG "android.hardware.health@2.0-service.celadon"
+#include <android-base/logging.h>
+
+#include <healthd/healthd.h>
+#include <health2/Health.h>
+#include <health2/service.h>
+#include <health2/powerSupplyType.h>
+#include <hidl/HidlTransportSupport.h>
+
+#include <utils/String8.h>
+#include <cutils/klog.h>
+#include <android-base/file.h>
+#include <android-base/strings.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <vector>
+#include <stdio.h>
+
+
+using android::hardware::health::V1_0::BatteryStatus;
+using android::hardware::health::V1_0::BatteryHealth;
+using namespace android;
+#define POWER_SUPPLY_SUBSYSTEM "power_supply"
+#define POWER_SUPPLY_SYSFS_PATH "/sys/class/" POWER_SUPPLY_SUBSYSTEM
+
+unsigned int platformPowerSupplyType = BATTERY;
+
+void healthd_board_init(struct healthd_config*)
+{
+	String8 path;
+
+	DIR* dir = opendir(POWER_SUPPLY_SYSFS_PATH);
+	if (dir == NULL) {
+		KLOG_ERROR(LOG_TAG, "Could not open %s\n", POWER_SUPPLY_SYSFS_PATH);
+	} else {
+		struct dirent* entry;
+
+		while ((entry = readdir(dir))) {
+			const char* name = entry->d_name;
+
+			if (!strcmp(name, ".") || !strcmp(name, "..")){
+				platformPowerSupplyType = CONSTANT_POWER;
+				continue;
+			}else
+				platformPowerSupplyType = BATTERY;
+		}
+
+	}
+	closedir(dir);
+}
+
+int healthd_board_battery_update(struct android::BatteryProperties *props)
+{
+
+	if (platformPowerSupplyType == CONSTANT_POWER) {
+		props->batteryStatus = android::BATTERY_STATUS_FULL;
+		props->batteryHealth = android::BATTERY_HEALTH_GOOD;
+		props->batteryLevel = 100;
+		props->batteryChargeCounter= 1000000;
+		props->batteryCurrent= 1000000;
+		props->chargerAcOnline = true;
+		props->chargerUsbOnline= false;
+		props->chargerWirelessOnline = false;
+		props->maxChargingCurrent= 2500000;
+		props->maxChargingVoltage= 4300000;
+		props->batteryPresent= true;
+		props->batteryVoltage= 1200000;
+		props->batteryTemperature= 25;
+		props->batteryFullCharge= 4200000;
+	} else
+		UNUSED(props);
+	return 0;
+}
+
+int main(void) {
+    return health_service_main();
+}
+

--- a/health/HealthServiceCommon.cpp
+++ b/health/HealthServiceCommon.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "health@2.0/"
+#include <android-base/logging.h>
+
+#include <android/hardware/health/1.0/types.h>
+#include <hal_conversion.h>
+#include <health2/Health.h>
+#include <health2/service.h>
+#include <healthd/healthd.h>
+#include <hidl/HidlTransportSupport.h>
+
+using android::hardware::IPCThreadState;
+using android::hardware::configureRpcThreadpool;
+using android::hardware::handleTransportPoll;
+using android::hardware::setupTransportPolling;
+using android::hardware::health::V2_0::HealthInfo;
+using android::hardware::health::V1_0::hal_conversion::convertToHealthInfo;
+using android::hardware::health::V2_0::IHealth;
+using android::hardware::health::V2_0::implementation::Health;
+
+extern int healthd_main(void);
+
+static int gBinderFd = -1;
+static std::string gInstanceName;
+
+static void binder_event(uint32_t /*epevents*/) {
+    if (gBinderFd >= 0) handleTransportPoll(gBinderFd);
+}
+
+void healthd_mode_service_2_0_init(struct healthd_config* config) {
+    LOG(INFO) << LOG_TAG << gInstanceName << " Hal is starting up...";
+
+    gBinderFd = setupTransportPolling();
+
+    if (gBinderFd >= 0) {
+        if (healthd_register_event(gBinderFd, binder_event))
+            LOG(ERROR) << LOG_TAG << gInstanceName << ": Register for binder events failed";
+    }
+
+    android::sp<IHealth> service = Health::initInstance(config);
+    CHECK_EQ(service->registerAsService(gInstanceName), android::OK)
+        << LOG_TAG << gInstanceName << ": Failed to register HAL";
+
+    LOG(INFO) << LOG_TAG << gInstanceName << ": Hal init done";
+}
+
+int healthd_mode_service_2_0_preparetowait(void) {
+    IPCThreadState::self()->flushCommands();
+    return -1;
+}
+
+void healthd_mode_service_2_0_heartbeat(void) {
+    // noop
+}
+
+void healthd_mode_service_2_0_battery_update(struct android::BatteryProperties* prop) {
+    HealthInfo info;
+    convertToHealthInfo(prop, info.legacy);
+    Health::getImplementation()->notifyListeners(&info);
+}
+
+static struct healthd_mode_ops healthd_mode_service_2_0_ops = {
+    .init = healthd_mode_service_2_0_init,
+    .preparetowait = healthd_mode_service_2_0_preparetowait,
+    .heartbeat = healthd_mode_service_2_0_heartbeat,
+    .battery_update = healthd_mode_service_2_0_battery_update,
+};
+
+int health_service_main(const char* instance) {
+    gInstanceName = instance;
+    if (gInstanceName.empty()) {
+        gInstanceName = "default";
+    }
+    healthd_mode_ops = &healthd_mode_service_2_0_ops;
+    LOG(INFO) << LOG_TAG << gInstanceName << ": Hal starting main loop...";
+    return healthd_main();
+}
+

--- a/health/android.hardware.health@2.0-service.celadon.rc
+++ b/health/android.hardware.health@2.0-service.celadon.rc
@@ -1,0 +1,5 @@
+service vendor.health-hal-2-0 /vendor/bin/hw/android.hardware.health@2.0-service.celadon
+  class hal
+  user system
+  group system
+  file /dev/kmsg w

--- a/health/healthd_common.cpp
+++ b/health/healthd_common.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "android.hardware.health@2.0-impl.celadon"
+#define KLOG_LEVEL 6
+
+#include <healthd/BatteryMonitor.h>
+#include <healthd/healthd.h>
+
+#include <batteryservice/BatteryService.h>
+#include <cutils/klog.h>
+#include <cutils/uevent.h>
+#include <errno.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <utils/Errors.h>
+
+#include <health2/Health.h>
+
+using namespace android;
+
+// Periodic chores fast interval in seconds
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 1)
+// Periodic chores fast interval in seconds
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW (60 * 10)
+
+static struct healthd_config healthd_config = {
+    .periodic_chores_interval_fast = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST,
+    .periodic_chores_interval_slow = DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW,
+    .batteryStatusPath = String8(String8::kEmptyString),
+    .batteryHealthPath = String8(String8::kEmptyString),
+    .batteryPresentPath = String8(String8::kEmptyString),
+    .batteryCapacityPath = String8(String8::kEmptyString),
+    .batteryVoltagePath = String8(String8::kEmptyString),
+    .batteryTemperaturePath = String8(String8::kEmptyString),
+    .batteryTechnologyPath = String8(String8::kEmptyString),
+    .batteryCurrentNowPath = String8(String8::kEmptyString),
+    .batteryCurrentAvgPath = String8(String8::kEmptyString),
+    .batteryChargeCounterPath = String8(String8::kEmptyString),
+    .batteryFullChargePath = String8(String8::kEmptyString),
+    .batteryCycleCountPath = String8(String8::kEmptyString),
+    .energyCounter = NULL,
+    .boot_min_cap = 0,
+    .screen_on = NULL,
+};
+
+static int eventct;
+static int epollfd;
+
+#define POWER_SUPPLY_SUBSYSTEM "power_supply"
+
+// epoll_create() parameter is actually unused
+#define MAX_EPOLL_EVENTS 40
+static int uevent_fd;
+static int wakealarm_fd;
+
+// -1 for no epoll timeout
+static int awake_poll_interval = -1;
+
+static int wakealarm_wake_interval = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST;
+
+using ::android::hardware::health::V2_0::implementation::Health;
+
+struct healthd_mode_ops* healthd_mode_ops = nullptr;
+
+int healthd_register_event(int fd, void (*handler)(uint32_t), EventWakeup wakeup) {
+    struct epoll_event ev;
+
+    ev.events = EPOLLIN;
+
+    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
+
+    ev.data.ptr = (void*)handler;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+        KLOG_ERROR(LOG_TAG, "epoll_ctl failed; errno=%d\n", errno);
+        return -1;
+    }
+
+    eventct++;
+    return 0;
+}
+
+static void wakealarm_set_interval(int interval) {
+    struct itimerspec itval;
+
+    if (wakealarm_fd == -1) return;
+
+    wakealarm_wake_interval = interval;
+
+    if (interval == -1) interval = 0;
+
+    itval.it_interval.tv_sec = interval;
+    itval.it_interval.tv_nsec = 0;
+    itval.it_value.tv_sec = interval;
+    itval.it_value.tv_nsec = 0;
+
+    if (timerfd_settime(wakealarm_fd, 0, &itval, NULL) == -1)
+        KLOG_ERROR(LOG_TAG, "wakealarm_set_interval: timerfd_settime failed\n");
+}
+
+void healthd_battery_update_internal(bool charger_online) {
+    // Fast wake interval when on charger (watch for overheat);
+    // slow wake interval when on battery (watch for drained battery).
+
+    int new_wake_interval = charger_online ? healthd_config.periodic_chores_interval_fast
+                                           : healthd_config.periodic_chores_interval_slow;
+
+    if (new_wake_interval != wakealarm_wake_interval) wakealarm_set_interval(new_wake_interval);
+
+    // During awake periods poll at fast rate.  If wake alarm is set at fast
+    // rate then just use the alarm; if wake alarm is set at slow rate then
+    // poll at fast rate while awake and let alarm wake up at slow rate when
+    // asleep.
+
+    if (healthd_config.periodic_chores_interval_fast == -1)
+        awake_poll_interval = -1;
+    else
+        awake_poll_interval = new_wake_interval == healthd_config.periodic_chores_interval_fast
+                                  ? -1
+                                  : healthd_config.periodic_chores_interval_fast * 1000;
+}
+
+static void healthd_battery_update(void) {
+    Health::getImplementation()->update();
+}
+
+static void periodic_chores() {
+    healthd_battery_update();
+}
+
+#define UEVENT_MSG_LEN 2048
+static void uevent_event(uint32_t /*epevents*/) {
+    char msg[UEVENT_MSG_LEN + 2];
+    char* cp;
+    int n;
+
+    n = uevent_kernel_multicast_recv(uevent_fd, msg, UEVENT_MSG_LEN);
+    if (n <= 0) return;
+    if (n >= UEVENT_MSG_LEN) /* overflow -- discard */
+        return;
+
+    msg[n] = '\0';
+    msg[n + 1] = '\0';
+    cp = msg;
+
+    while (*cp) {
+        if (!strcmp(cp, "SUBSYSTEM=" POWER_SUPPLY_SUBSYSTEM)) {
+            healthd_battery_update();
+            break;
+        }
+
+        /* advance to after the next \0 */
+        while (*cp++)
+            ;
+    }
+}
+
+static void uevent_init(void) {
+    uevent_fd = uevent_open_socket(64 * 1024, true);
+
+    if (uevent_fd < 0) {
+        KLOG_ERROR(LOG_TAG, "uevent_init: uevent_open_socket failed\n");
+        return;
+    }
+
+    fcntl(uevent_fd, F_SETFL, O_NONBLOCK);
+    if (healthd_register_event(uevent_fd, uevent_event, EVENT_WAKEUP_FD))
+        KLOG_ERROR(LOG_TAG, "register for uevent events failed\n");
+}
+
+static void wakealarm_event(uint32_t /*epevents*/) {
+    unsigned long long wakeups;
+
+    if (read(wakealarm_fd, &wakeups, sizeof(wakeups)) == -1) {
+        KLOG_ERROR(LOG_TAG, "wakealarm_event: read wakealarm fd failed\n");
+        return;
+    }
+
+    periodic_chores();
+}
+
+static void wakealarm_init(void) {
+    wakealarm_fd = timerfd_create(CLOCK_BOOTTIME_ALARM, TFD_NONBLOCK);
+    if (wakealarm_fd == -1) {
+        KLOG_ERROR(LOG_TAG, "wakealarm_init: timerfd_create failed\n");
+        return;
+    }
+
+    if (healthd_register_event(wakealarm_fd, wakealarm_event, EVENT_WAKEUP_FD))
+        KLOG_ERROR(LOG_TAG, "Registration of wakealarm event failed\n");
+
+    wakealarm_set_interval(healthd_config.periodic_chores_interval_fast);
+}
+
+static void healthd_mainloop(void) {
+    int nevents = 0;
+    while (1) {
+        struct epoll_event events[eventct];
+        int timeout = awake_poll_interval;
+        int mode_timeout;
+
+        /* Don't wait for first timer timeout to run periodic chores */
+        if (!nevents) periodic_chores();
+
+        healthd_mode_ops->heartbeat();
+
+        mode_timeout = healthd_mode_ops->preparetowait();
+        if (timeout < 0 || (mode_timeout > 0 && mode_timeout < timeout)) timeout = mode_timeout;
+        nevents = epoll_wait(epollfd, events, eventct, timeout);
+        if (nevents == -1) {
+            if (errno == EINTR) continue;
+            KLOG_ERROR(LOG_TAG, "healthd_mainloop: epoll_wait failed\n");
+            break;
+        }
+
+        for (int n = 0; n < nevents; ++n) {
+            if (events[n].data.ptr) (*(void (*)(int))events[n].data.ptr)(events[n].events);
+        }
+    }
+
+    return;
+}
+
+static int healthd_init() {
+    epollfd = epoll_create(MAX_EPOLL_EVENTS);
+    if (epollfd == -1) {
+        KLOG_ERROR(LOG_TAG, "epoll_create failed; errno=%d\n", errno);
+        return -1;
+    }
+
+    healthd_mode_ops->init(&healthd_config);
+    wakealarm_init();
+    uevent_init();
+
+    return 0;
+}
+
+int healthd_main() {
+    int ret;
+
+    klog_set_level(KLOG_LEVEL);
+
+    if (!healthd_mode_ops) {
+        KLOG_ERROR("healthd ops not set, exiting\n");
+        exit(1);
+    }
+
+    ret = healthd_init();
+    if (ret) {
+        KLOG_ERROR("Initialization failed, exiting\n");
+        exit(2);
+    }
+
+    healthd_mainloop();
+    KLOG_ERROR("Main loop terminated, exiting\n");
+    return 3;
+}
+

--- a/health/include/health2/Health.h
+++ b/health/include/health2/Health.h
@@ -1,0 +1,78 @@
+#ifndef ANDROID_HARDWARE_HEALTH_V2_0_HEALTH_H
+#define ANDROID_HARDWARE_HEALTH_V2_0_HEALTH_H
+
+#include <memory>
+#include <vector>
+
+#include <android/hardware/health/1.0/types.h>
+#include <android/hardware/health/2.0/IHealth.h>
+#include <healthd/BatteryMonitor.h>
+#include <hidl/Status.h>
+
+using android::hardware::health::V2_0::StorageInfo;
+using android::hardware::health::V2_0::DiskStats;
+
+void get_storage_info(std::vector<struct StorageInfo>& info);
+void get_disk_stats(std::vector<struct DiskStats>& stats);
+
+namespace android {
+namespace hardware {
+namespace health {
+namespace V2_0 {
+namespace implementation {
+
+using V1_0::BatteryStatus;
+
+using ::android::hidl::base::V1_0::IBase;
+
+struct Health : public IHealth, hidl_death_recipient {
+   public:
+    static sp<IHealth> initInstance(struct healthd_config* c);
+    // Should only be called by implementation itself (-impl, -service).
+    // Clients should not call this function. Instead, initInstance() initializes and returns the
+    // global instance that has fewer functions.
+    // TODO(b/62229583): clean up and hide these functions after update() logic is simplified.
+    static sp<Health> getImplementation();
+
+    Health(struct healthd_config* c);
+
+    // TODO(b/62229583): clean up and hide these functions after update() logic is simplified.
+    void notifyListeners(HealthInfo* info);
+
+    // Methods from IHealth follow.
+    Return<Result> registerCallback(const sp<IHealthInfoCallback>& callback) override;
+    Return<Result> unregisterCallback(const sp<IHealthInfoCallback>& callback) override;
+    Return<Result> update() override;
+    Return<void> getChargeCounter(getChargeCounter_cb _hidl_cb) override;
+    Return<void> getCurrentNow(getCurrentNow_cb _hidl_cb) override;
+    Return<void> getCurrentAverage(getCurrentAverage_cb _hidl_cb) override;
+    Return<void> getCapacity(getCapacity_cb _hidl_cb) override;
+    Return<void> getEnergyCounter(getEnergyCounter_cb _hidl_cb) override;
+    Return<void> getChargeStatus(getChargeStatus_cb _hidl_cb) override;
+    Return<void> getStorageInfo(getStorageInfo_cb _hidl_cb) override;
+    Return<void> getDiskStats(getDiskStats_cb _hidl_cb) override;
+    Return<void> getHealthInfo(getHealthInfo_cb _hidl_cb) override;
+
+    // Methods from ::android::hidl::base::V1_0::IBase follow.
+    Return<void> debug(const hidl_handle& fd, const hidl_vec<hidl_string>& args) override;
+
+    void serviceDied(uint64_t cookie, const wp<IBase>& /* who */) override;
+
+   private:
+    static sp<Health> instance_;
+
+    std::mutex callbacks_lock_;
+    std::vector<sp<IHealthInfoCallback>> callbacks_;
+    std::unique_ptr<BatteryMonitor> battery_monitor_;
+
+    bool unregisterCallbackInternal(const sp<IBase>& cb);
+};
+
+}  // namespace implementation
+}  // namespace V2_0
+}  // namespace health
+}  // namespace hardware
+}  // namespace android
+
+#endif  // ANDROID_HARDWARE_HEALTH_V2_0_HEALTH_H
+

--- a/health/include/health2/powerSupplyType.h
+++ b/health/include/health2/powerSupplyType.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_HARDWARE_POWER_SUPPLY_TYPE
+#define ANDROID_HARDWARE_POWER_SUPPLY_TYPE
+
+enum  powerType {
+        CONSTANT_POWER = 0,
+        BATTERY,
+};
+#endif  // ANDROID_HARDWARE_POWER_SUPPLY_TYPE

--- a/health/include/health2/service.h
+++ b/health/include/health2/service.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_HARDWARE_HEALTH_V2_0_SERVICE_COMMON
+#define ANDROID_HARDWARE_HEALTH_V2_0_SERVICE_COMMON
+
+int health_service_main(const char* instance = "");
+
+#endif  // ANDROID_HARDWARE_HEALTH_V2_0_SERVICE_COMMON
+

--- a/manifest.xml
+++ b/manifest.xml
@@ -129,5 +129,13 @@
               <instance>sample-all</instance>
           </interface>
     </hal>
-
+    <hal format="hidl">
+        <name>android.hardware.health</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IHealth</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </manifest>

--- a/sepolicy/health_hal/file.te
+++ b/sepolicy/health_hal/file.te
@@ -1,0 +1,3 @@
+# health_hal files
+type sysfs_health2_0_management, fs_type, sysfs_type;
+

--- a/sepolicy/health_hal/file_contexts
+++ b/sepolicy/health_hal/file_contexts
@@ -1,0 +1,2 @@
+/vendor/bin/hw/android\.hardware\.health@2\.0-service\.celadon          u:object_r:hal_health_default_exec:s0
+

--- a/sepolicy/health_hal/hal_health2_0_default.te
+++ b/sepolicy/health_hal/hal_health2_0_default.te
@@ -1,0 +1,5 @@
+# health info abstraction
+
+allow hal_health_default sysfs_health2_0_management:dir r_dir_perms;
+allow hal_health_default sysfs_health2_0_management:file rw_file_perms;
+allow hal_health_default sysfs_health2_0_management:lnk_file r_file_perms;


### PR DESCRIPTION
Current celadon platforms are not battery operated systems.
Android 9 onwards, the battery less devices status reporting has
changed. This caused cts failures.

Ref: https://source.android.com/devices/tech/power/batteryless
+-------------------------------------------------------------------------------+
|  Battery State             |  Android 9 and higher  |  Android 8.1 and lower  |
+-------------------------------------------------------------------------------+
|  Present                   |    false               |    true                 |
|  Status                    |    unknown             |    charging             |
|  Remaining Capacity        |    0                   |    100                  |
|  Health                    |    unknown             |    good                 |
|  AC charger online status  |    not modified        |    forced to true       |
+-------------------------------------------------------------------------------+

As per google's recommendation, OEMs can implement HAL to
overcome/report the status as desired.

Tracked-On: OAM-71291
Signed-off-by: Liu, PengX <pengx.liu@intel.com>
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>