### PR TITLE
thermal-daemon: Update sepolicy as per VNDK rules

### DIFF
--- a/sepolicy/thermal/thermal-daemon/file.te
+++ b/sepolicy/thermal/thermal-daemon/file.te
@@ -1,4 +1,4 @@
-type thermal-daemon_data_file, file_type, data_file_type;
+type thermal-daemon_data_file, vendor_file_type, file_type;
 type sysfs_dmi_id, fs_type, sysfs_type;
 type sysfs_backlight_thermal, fs_type, sysfs_type;
-type thermal-daemon_run_dir, fs_type, data_file_type;
+type thermal-daemon_run_dir, file_type, data_file_type;

--- a/sepolicy/thermal/thermal-daemon/file_contexts
+++ b/sepolicy/thermal/thermal-daemon/file_contexts
@@ -1,6 +1,6 @@
 /vendor/bin/thermal-daemon        u:object_r:thermal-daemon_exec:s0
 /vendor/etc/thermal_daemon(/.*)?        u:object_r:thermal-daemon_data_file:s0
-/data/misc/thermal-daemon(/.*)?	u:object_r:thermal-daemon_run_dir:s0
+/data/vendor/thermal_daemon(/.*)?       u:object_r:thermal-daemon_run_dir:s0
 /sys/devices/virtual/dmi/id/product_name		u:object_r:sysfs_dmi_id:s0
 /sys/devices/virtual/dmi/id/product_uuid		u:object_r:sysfs_dmi_id:s0
 /sys/class/backlight(/.*)?		u:object_r:sysfs_backlight_thermal:s0

--- a/sepolicy/thermal/thermal-daemon/init.te
+++ b/sepolicy/thermal/thermal-daemon/init.te
@@ -1,8 +1,8 @@
 allow init sysfs_powercap:dir { read open };
 allow init sysfs_powercap:file { read setattr };
 allow init thermal-daemon_data_file: dir { read open };
-allow init thermal-daemon_data_file: file { read setattr };
-allow init thermal-daemon_run_dir: dir { create read open };
+allow init thermal-daemon_data_file: file { read };
+allow init thermal-daemon_run_dir: dir { create read open setattr };
 allow init thermal-daemon_run_dir: file { create read write setattr };
 allow init sysfs_dmi_id: file { read setattr };
 allow init sysfs_backlight_thermal: file { read write setattr };

--- a/sepolicy/thermal/thermal-daemon/thermal-daemon.te
+++ b/sepolicy/thermal/thermal-daemon/thermal-daemon.te
@@ -23,10 +23,14 @@ allow thermal-daemon sysfs_dmi_id:{ file lnk_file } rw_file_perms;
 allow thermal-daemon system_data_file:dir create_dir_perms;
 allow thermal-daemon system_data_file:dir rw_dir_perms;
 allow thermal-daemon thermal-daemon_run_dir:dir create_dir_perms;
+allow thermal-daemon thermal-daemon_run_dir:dir rw_dir_perms;
 allow thermal-daemon thermal-daemon_run_dir:file create_file_perms;
+allow thermal-daemon thermal-daemon_run_dir:file rw_file_perms;
 allow thermal-daemon thermal-daemon_data_file:dir r_file_perms;
 allow thermal-daemon thermal-daemon_data_file:file r_file_perms;
 allow thermal-daemon thermal_device:chr_file rw_file_perms;
+allow thermal-daemon self:netlink_kobject_uevent_socket create_socket_perms;
+
 
 # properties
 set_prop(thermal-daemon, powerctl_prop)


### PR DESCRIPTION
As per VNDK rules, data files directory for vendor apps should
be in vendor folder. Hence moving data dir from /data/misc to
/data/vendor folder.

Tracked-On: OAM-71986
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>