### PR TITLE
[MIXINUP]Move TARGET_BOARD_PLATFORM from boot-arch to project-celadon

### DIFF
--- a/cel_apl/BoardConfig.mk
+++ b/cel_apl/BoardConfig.mk
@@ -167,8 +167,6 @@ BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/config-partition
 ##############################################################
 #TARGET_NO_RECOVERY ?= false
 
-TARGET_BOARD_PLATFORM := project-celadon
-
 ifeq (False,true)
 TARGET_USERIMAGES_USE_F2FS := true
 BOARD_USERDATAIMAGE_FILE_SYSTEM_TYPE := f2fs

--- a/cel_apl/device.mk
+++ b/cel_apl/device.mk
@@ -3,6 +3,8 @@
 ##############################################################
 # Source: device/intel/mixins/groups/project-celadon/default/product.mk
 ##############################################################
+TARGET_BOARD_PLATFORM := project-celadon
+
 #Product Characteristics
 PRODUCT_DIR := $(dir $(lastword $(filter-out device/common/%,$(filter device/%,$(ALL_PRODUCTS)))))
 

--- a/celadon/BoardConfig.mk
+++ b/celadon/BoardConfig.mk
@@ -171,8 +171,6 @@ BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/config-partition
 ##############################################################
 #TARGET_NO_RECOVERY ?= false
 
-TARGET_BOARD_PLATFORM := project-celadon
-
 ifeq (False,true)
 TARGET_USERIMAGES_USE_F2FS := true
 BOARD_USERDATAIMAGE_FILE_SYSTEM_TYPE := f2fs

--- a/celadon/device.mk
+++ b/celadon/device.mk
@@ -3,6 +3,8 @@
 ##############################################################
 # Source: device/intel/mixins/groups/project-celadon/default/product.mk
 ##############################################################
+TARGET_BOARD_PLATFORM := project-celadon
+
 #Product Characteristics
 PRODUCT_DIR := $(dir $(lastword $(filter-out device/common/%,$(filter device/%,$(ALL_PRODUCTS)))))
 


### PR DESCRIPTION
Move it to make sure TARGET_BOARD_PLATFORM getting definded
before using as device.mk gets running before BoardConfig.mk

Tracked-On: OAM-72181
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>