### PR TITLE
thermal-daemon: Update thermal policy as per the critical limits in coretemp hwmon

### DIFF
--- a/common/thermal/thermal-conf.xml
+++ b/common/thermal/thermal-conf.xml
@@ -11,7 +11,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>90000</Temperature>
+						<Temperature>85000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -19,7 +19,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>105000</Temperature>
+						<Temperature>95000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
@@ -32,7 +32,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>110000</Temperature>
+						<Temperature>99000</Temperature>
 						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
@@ -67,7 +67,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>90000</Temperature>
+						<Temperature>85000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -75,7 +75,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>105000</Temperature>
+						<Temperature>95000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
@@ -88,7 +88,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>110000</Temperature>
+						<Temperature>99000</Temperature>
 						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
@@ -131,7 +131,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>105000</Temperature>
+						<Temperature>100000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
@@ -144,7 +144,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>110000</Temperature>
+						<Temperature>104000</Temperature>
 						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>


### PR DESCRIPTION
temp_crit for cpus set as follows for all platforms:
KBL-NUC Commercial devices: 100
KBL-NUC Development devices: 100
APL-NUC Development devices: 105

Hence redefined the thermal policy as follows:
KBL-NUC Commercial and Development devices:
Passive limit 1: 85 C
Passive limit 2: 95 C
Critical limit: 99 C

APL-NUC devices:
Passive limit 1: 90 C
Passive limit 2: 100 C
Critical limit: 104 C

Tracked-On: OAM-72228
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>