### PR TITLE
support adoptable storage on usb

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -12,7 +12,7 @@ graphics: project-celadon(gen9+=true,hwc2=true,vulkan=true,drmhwc=false,minigbm=
 media: project-celadon(mediasdk=false,media_sdk_source=false)
 ethernet: dhcp
 debugfs: default
-storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=false)
+storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=true)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true


### PR DESCRIPTION
since there is no sd card slot on Commercial KBL-NUC, use adoptable usb
to test related function instead

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-72351
Signed-off-by: Zhiwei li zhiwei.li@intel.com