### PR TITLE
[MIXINUP] set loop device max_part

### DIFF
--- a/cel_apl/BoardConfig.mk
+++ b/cel_apl/BoardConfig.mk
@@ -97,7 +97,7 @@ KERNEL_LOGLEVEL ?= 3
 SERIAL_PARAMETER ?= console=tty0 console=ttyS0,115200n8
 
 
-BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path=/vendor/firmware loglevel=$(KERNEL_LOGLEVEL)
+BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path=/vendor/firmware loglevel=$(KERNEL_LOGLEVEL) loop.max_part=7
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(SPARSE_IMG),true)

--- a/celadon/BoardConfig.mk
+++ b/celadon/BoardConfig.mk
@@ -101,7 +101,7 @@ KERNEL_LOGLEVEL ?= 3
 SERIAL_PARAMETER ?= console=tty0 console=ttyS0,115200n8
 
 
-BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path=/vendor/firmware loglevel=$(KERNEL_LOGLEVEL)
+BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path=/vendor/firmware loglevel=$(KERNEL_LOGLEVEL) loop.max_part=7
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(SPARSE_IMG),true)


### PR DESCRIPTION
set loop device max_part so that virtual sd card can be partitioned and
formatted without error.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-72409
Signed-off-by: Zhiwei li zhiwei.li@intel.com