### PR TITLE
celadon: Add socperf and socwatch in extra kernel module path

### DIFF
--- a/cel_apl/AndroidBoard.mk
+++ b/cel_apl/AndroidBoard.mk
@@ -64,6 +64,9 @@ $(PRODUCT_OUT)/kernel: $(KERNEL_CONFIG) | $(ACP)
 
 EXTMOD_SRC := ../../../../../..
 
+TARGET_EXTRA_KERNEL_MODULES := $(EXTMOD_SRC)/kernel/modules/perftools-external/soc_perf_driver/src
+TARGET_EXTRA_KERNEL_MODULES += $(EXTMOD_SRC)/kernel/modules/perftools-external/socwatch_driver
+
 ALL_EXTRA_MODULES := $(patsubst %,$(TARGET_OUT_INTERMEDIATES)/kmodule/%,$(TARGET_EXTRA_KERNEL_MODULES))
 $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kernel
 	@echo Building additional kernel module $*

--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -16,7 +16,7 @@ storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=true)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true
-kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
+kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true, external_modules=perftools-external/soc_perf_driver/src perftools-external/socwatch_driver)
 bluetooth: btusb (ivi=true)
 boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true)
 audio: project-celadon

--- a/celadon/AndroidBoard.mk
+++ b/celadon/AndroidBoard.mk
@@ -64,6 +64,9 @@ $(PRODUCT_OUT)/kernel: $(KERNEL_CONFIG) | $(ACP)
 
 EXTMOD_SRC := ../../../../../..
 
+TARGET_EXTRA_KERNEL_MODULES := $(EXTMOD_SRC)/kernel/modules/perftools-external/soc_perf_driver/src
+TARGET_EXTRA_KERNEL_MODULES += $(EXTMOD_SRC)/kernel/modules/perftools-external/socwatch_driver
+
 ALL_EXTRA_MODULES := $(patsubst %,$(TARGET_OUT_INTERMEDIATES)/kmodule/%,$(TARGET_EXTRA_KERNEL_MODULES))
 $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kernel
 	@echo Building additional kernel module $*

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -17,7 +17,7 @@ storage: sdcard-mmc0-usb-sd(adoptablesd=false,adoptableusb=true)
 display-density: default
 usb-gadget: g_ffs
 adb_net: true
-kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true)
+kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true, external_modules=perftools-external/soc_perf_driver/src perftools-external/socwatch_driver)
 bluetooth: btusb
 boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true)
 audio: project-celadon


### PR DESCRIPTION
It adds socperf and socwatch kernel-modules in extra kernel modules
to consider extra modules for compile and build.

Signed-off-by: Punit Vara <punit.vara@intel.com>