### PR TITLE
Add sepolicy for SystemUpdater and update_engine

### DIFF
--- a/sepolicy/boot-arch/project-celadon/cel_apl/update_engine.te
+++ b/sepolicy/boot-arch/project-celadon/cel_apl/update_engine.te
@@ -3,3 +3,9 @@ allow update_engine tmpfs:dir r_dir_perms;
 allow update_engine tmpfs:file r_file_perms;
 allow update_engine tmpfs:lnk_file r_file_perms;
 allow update_engine vendor_shell_exec:file rx_file_perms;
+
+allow update_engine platform_app:binder call;
+allow update_engine vfat:dir search;
+allow update_engine vfat:file r_file_perms;
+allow update_engine mnt_media_rw_file:file r_file_perms;
+allow update_engine mnt_media_rw_file:dir r_dir_perms;

--- a/sepolicy/boot-arch/project-celadon/celadon/update_engine.te
+++ b/sepolicy/boot-arch/project-celadon/celadon/update_engine.te
@@ -3,3 +3,9 @@ allow update_engine tmpfs:dir r_dir_perms;
 allow update_engine tmpfs:file r_file_perms;
 allow update_engine tmpfs:lnk_file r_file_perms;
 allow update_engine vendor_shell_exec:file rx_file_perms;
+
+allow update_engine platform_app:binder call;
+allow update_engine vfat:dir search;
+allow update_engine vfat:file r_file_perms;
+allow update_engine mnt_media_rw_file:file r_file_perms;
+allow update_engine mnt_media_rw_file:dir r_dir_perms;

--- a/sepolicy/car/platform_app.te
+++ b/sepolicy/car/platform_app.te
@@ -1,1 +1,5 @@
 allow platform_app broadcastradio_service:service_manager find;
+
+#allow SystemUpdater app to call UpdateEngine
+allow platform_app update_engine:binder { call transfer };
+allow platform_app update_engine_service:service_manager find;


### PR DESCRIPTION
allow SystemUpdater to invoke update_engine server,
update_engine can access the OTA file in removable storage.

Tracked-On: OAM-73579
Signed-off-by: hengluo <heng.luo@intel.com>