### PR TITLE
Add the boot HIDL.

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -138,4 +138,13 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="hidl">
+        <name>android.hardware.boot</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+        <name>IBootControl</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </manifest>


### PR DESCRIPTION
It is needed to support Treble.
Currently use boot HAL 1.0.

Tracked-On: OAM-74780
Signed-off-by: Ming Tan <ming.tan@intel.com>