### PR TITLE
Add kernel config for ramdump decoding support

### DIFF
--- a/kernel_config/debug_diffconfig
+++ b/kernel_config/debug_diffconfig
@@ -1,0 +1,2 @@
+#Debug configuration options
+CONFIG_DEBUG_INFO=y


### PR DESCRIPTION
Currently, both user/user debug use same kernel config,
this patch add kernel debug config for celadon.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-75275
Signed-off-by: Baofeng, Tian baofeng.tian@intel.com