### PR TITLE
set_storage: Fix the sepolicy issue when set API level to 28

### DIFF
--- a/sepolicy/set_storage/set_storage.te
+++ b/sepolicy/set_storage/set_storage.te
@@ -29,3 +29,4 @@ allow set_storage block_device:blk_file { getattr setattr };
 # allow set_storage frp_block_device:blk_file setattr;
 
 allow set_storage set_storage:capability { fowner chown };
+allow set_storage default_prop:file { getattr map open read setattr };


### PR DESCRIPTION
After set API level to 28, it will report deny some operation for
default_prop:file

Tracked-On: OAM-75347
Signed-off-by: Ming Tan <ming.tan@intel.com>