### PR TITLE
boot-arch: set wdat watchdog timeout

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -18,7 +18,7 @@ usb-gadget: g_ffs
 adb_net: true
 kernel: project-celadon(loglevel=3, disable_cpuidle_on_boot=true, external_modules=perftools-external/soc_perf_driver/src perftools-external/socwatch_driver)
 bluetooth: btusb (ivi=true)
-boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true)
+boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,watchdog_parameters=10 30)
 audio: project-celadon
 wlan: iwlwifi
 cpu-arch: skl


### PR DESCRIPTION
set watchdog timeout as 40s in cel_apl.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-72641
Signed-off-by: Tian, Baofeng baofeng.tian@intel.com
Signed-off-by: Duan, YayongX yayongx.duan@intel.com