### PR TITLE
Fix typo error for vulkan library

### DIFF
--- a/sepolicy/graphics/project-celadon/file_contexts
+++ b/sepolicy/graphics/project-celadon/file_contexts
@@ -13,7 +13,7 @@
 /(vendor|system/vendor)/lib(64)?/libdrm_intel_pri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.project-celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0
-/(vendor|system/vendor)/lib(64)?/hw/vulkan\.project-broxton\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/hw/vulkan\.project-celadon\.so u:object_r:same_process_hal_file:s0
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/libpciaccess\.so u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
The typo error will cause CTS dEQP vulkan module failure, this
commit help fix this issue.

Tracked-On:
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>