### PR TITLE
SELinux: grant some permissions for vendor_init

### DIFF
--- a/sepolicy/domain.te
+++ b/sepolicy/domain.te
@@ -1,0 +1,1 @@
+allow domain system_file:dir r_dir_perms;

--- a/sepolicy/vendor_init.te
+++ b/sepolicy/vendor_init.te
@@ -1,0 +1,3 @@
+allow vendor_init self:global_capability_class_set sys_module;
+allow vendor_init vendor_file:system module_load;
+allow vendor_init kernel:key search;


### PR DESCRIPTION
Some kernel modules need to be loaded by vendor_init, grant
the relevant permissions to vendor_init.

Tracked-On: None

Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>