### PR TITLE
[MIXUP]Fix CtsVerifier Bugreport collection fail

### DIFF
--- a/cel_apl/init.rc
+++ b/cel_apl/init.rc
@@ -113,7 +113,7 @@ on charger
     start watchdogd
 
 # bugreport is triggered by holding down volume down, volume up and power
-service bugreport /system/bin/dumpstate -d -p -B \
+service bugreport /system/bin/dumpstate -d -p -B -z \
 	-o /data/user_de/0/com.android.shell/files/bugreports/bugreport
     class main
     disabled

--- a/cel_kbl/init.rc
+++ b/cel_kbl/init.rc
@@ -113,7 +113,7 @@ on charger
     start watchdogd
 
 # bugreport is triggered by holding down volume down, volume up and power
-service bugreport /system/bin/dumpstate -d -p -B \
+service bugreport /system/bin/dumpstate -d -p -B -z \
 	-o /data/user_de/0/com.android.shell/files/bugreports/bugreport
     class main
     disabled

--- a/celadon/init.rc
+++ b/celadon/init.rc
@@ -113,7 +113,7 @@ on charger
     start watchdogd
 
 # bugreport is triggered by holding down volume down, volume up and power
-service bugreport /system/bin/dumpstate -d -p -B \
+service bugreport /system/bin/dumpstate -d -p -B -z \
 	-o /data/user_de/0/com.android.shell/files/bugreports/bugreport
     class main
     disabled


### PR DESCRIPTION
Add -z option to bugreport service. New version of bugreport(dumpstate)
requires -z CLI option. The dumpstate will exit before doing actual dump
if lack of -z option. That will cause bugreport collection fail.

Tracked-On: OAM-75535
Signed-off-by: Yan, WalterX walterx.yan@intel.com