### PR TITLE
remove simics files

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -50,7 +50,7 @@ avb: true
 health: true
 slot-ab: true
 art-config: default
-gptbuild: true(size=14G)
+gptbuild: true(size=14G,generate_craff=false)
 device-type: car
 swap:zram(size=1073741824,swappiness=false,hardware=cel_apl)
 power: true

--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -50,7 +50,7 @@ avb: true
 health: true
 slot-ab: true
 art-config: default
-gptbuild: true(size=14G)
+gptbuild: true(size=14G,generate_craff=false)
 device-type: car
 swap:zram(size=1073741824,swappiness=false,hardware=cel_kbl)
 power: true

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -51,6 +51,6 @@ avb: true
 health: true
 slot-ab: true
 art-config: default
-gptbuild: true(size=14G)
+gptbuild: true(size=14G,generate_craff=false)
 swap:zram(size=1073741824,swappiness=false,hardware=celadon)
 power: true


### PR DESCRIPTION
Add option to build craff file, so in Celadon project
we can disable use of simics tools.

Tracked-On: OAM-75249
Signed-off-by: phireg <philippe.regnier@intel.com>