### PR TITLE
sepolicy: remove setattr of default_prop:file from set_storage.

### DIFF
--- a/sepolicy/set_storage/set_storage.te
+++ b/sepolicy/set_storage/set_storage.te
@@ -29,4 +29,4 @@ allow set_storage block_device:blk_file { getattr setattr };
 # allow set_storage frp_block_device:blk_file setattr;
 
 allow set_storage set_storage:capability { fowner chown };
-allow set_storage default_prop:file { getattr map open read setattr };
+allow set_storage default_prop:file { getattr map open read };


### PR DESCRIPTION
It can fix the issue of SELinuxNeverallowRulesTest failed in
CtsSecurityHostTestCases Module.

Tracked-On: OAM-76043
Signed-off-by: Ming Tan <ming.tan@intel.com>