### PR TITLE
vendor_init: Add sepolicy to set service.adb.tcp.port prop

### DIFF
--- a/sepolicy/vendor_init.te
+++ b/sepolicy/vendor_init.te
@@ -2,3 +2,4 @@ allow vendor_init self:global_capability_class_set sys_module;
 allow vendor_init vendor_file:system module_load;
 allow vendor_init kernel:key search;
 allow vendor_init file_contexts_file:file map;
+set_prop(vendor_init, shell_prop)


### PR DESCRIPTION
Adb over ethernet/wifi not working as sepolicy for vendor_init
to set the property service.adb.tcp.port is missing.

As service.adb.tcp.port is defined to shell_prop, add
sepolicy for vendor_init to set the shell_prop.

Tracked-On: OAM-76057
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>