### PR TITLE
Fix: treble support for Camera to avoid crash

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -133,6 +133,15 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.camera.provider</name>
+        <transport>hwbinder</transport>
+        <version>2.4</version>
+        <interface>
+            <name>ICameraProvider</name>
+            <instance>external/0</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.configstore</name>
         <transport>hwbinder</transport>
         <version>1.0</version>

--- a/sepolicy/camera-ext/ext-camera-only/cameraserver.te
+++ b/sepolicy/camera-ext/ext-camera-only/cameraserver.te
@@ -1,4 +1,4 @@
 #============= cameraserver ==============
 allow cameraserver gpu_device:dir search;
-allow cameraserver hal_graphics_allocator_default_tmpfs:file map;
-allow cameraserver hal_graphics_allocator_default_tmpfs:file { read write };
+allow cameraserver gpu_device:chr_file { ioctl open read write };
+allow cameraserver hal_graphics_allocator_default_tmpfs:file { read write map};

--- a/sepolicy/camera-ext/ext-camera-only/hal_camera_default.te
+++ b/sepolicy/camera-ext/ext-camera-only/hal_camera_default.te
@@ -1,4 +1,7 @@
 #============= hal_camera_default ==============
+vndbinder_use(hal_camera_default);
+
 allow hal_camera_default gpu_device:chr_file { ioctl open read write };
 allow hal_camera_default gpu_device:dir search;
 allow hal_camera_default hal_graphics_allocator_default_tmpfs:file { map read write };
+allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;


### PR DESCRIPTION
Add Camera treble support in the Celadon branch
to avoid camera crash

Tracked-On: OAM-76120
Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>