### PR TITLE
Debug: Fix some treble violations for debug module

### DIFF
--- a/sepolicy/coredump/file.te
+++ b/sepolicy/coredump/file.te
@@ -1,1 +1,1 @@
-type coredump_log_file, mlstrustedobject, file_type, data_file_type;
+type coredump_log_file, mlstrustedobject, file_type, data_file_type, core_data_file_type;

--- a/sepolicy/crashlogd/crashlogd.te
+++ b/sepolicy/crashlogd/crashlogd.te
@@ -1,7 +1,7 @@
 userdebug_or_eng(`
   # Rules for crashlogd
   type crashlogd, domain;
-  type crashlogd_exec, exec_type, file_type;
+  type crashlogd_exec, exec_type, file_type, vendor_file_type;
   init_daemon_domain(crashlogd)
   permissive crashlogd;
 
@@ -35,6 +35,5 @@ userdebug_or_eng(`
   dontaudit crashlogd property_type:file *;
   # dontaudit crashlogd domain:debuggerd *;
   dontaudit crashlogd service_manager_type:service_manager *;
-
-  binder_use(crashlogd);
+  dontaudit crashlogd servicemanager: binder *;
 ')

--- a/sepolicy/crashlogd/dumpstate.te
+++ b/sepolicy/crashlogd/dumpstate.te
@@ -1,5 +1,4 @@
 allow dumpstate block_device:blk_file getattr;
-allow dumpstate config_file:dir r_dir_perms;
 allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
 allow dumpstate kernel:system module_request;
 allow dumpstate self:netlink_xfrm_socket create;

--- a/sepolicy/crashlogd/dumpstate_dropbox.te
+++ b/sepolicy/crashlogd/dumpstate_dropbox.te
@@ -1,6 +1,6 @@
 userdebug_or_eng(`
   type dumpstate_dropbox, domain;
-  type dumpstate_dropbox_exec, exec_type, file_type;
+  type dumpstate_dropbox_exec, exec_type, file_type, vendor_file_type;
 
   domain_auto_trans(init, dumpstate_dropbox_exec, dumpstate_dropbox)
 
@@ -11,17 +11,17 @@ userdebug_or_eng(`
 
   allow domain dumpstate_dropbox:fd use;
 
-  allow dumpstate_dropbox dropbox_service:service_manager find;
+  dontaudit dumpstate_dropbox dropbox_service:service_manager find;
 
-  binder_use(dumpstate_dropbox);
-  binder_call(system_server, dumpstate_dropbox);
   set_prop(dumpstate_dropbox, ctl_dumpstate_prop)
-  unix_socket_connect(dumpstate_dropbox, dumpstate, dumpstate)
 
   # Execute shell scripts, toolbox and system bin files.
-  allow dumpstate_dropbox toolbox_exec:file rx_file_perms;
-  allow dumpstate_dropbox shell_exec:file rx_file_perms;
-  allow dumpstate_dropbox system_file:file rx_file_perms;
-  allow dumpstate_dropbox system_data_file:dir { add_name write };
-
+  dontaudit dumpstate_dropbox toolbox_exec:file rx_file_perms;
+  dontaudit dumpstate_dropbox shell_exec:file rx_file_perms;
+  dontaudit dumpstate_dropbox system_file:file rx_file_perms;
+  dontaudit dumpstate_dropbox system_data_file:dir { add_name write };
+  dontaudit dumpstate_dropbox domain:binder *;
+  dontaudit dumpstate_dropbox binder_device: chr_file *;
+  dontaudit dumpstate_dropbox default_prop:file *;
+  dontaudit dumpstate_dropbox binder_device:chr_file *;
 ')

--- a/sepolicy/crashlogd/property.te
+++ b/sepolicy/crashlogd/property.te
@@ -1,1 +1,1 @@
-type crashlogd_prop, property_type;
+type vendor_crashlogd_prop, property_type;

--- a/sepolicy/crashlogd/property_contexts
+++ b/sepolicy/crashlogd/property_contexts
@@ -1,2 +1,2 @@
 # user changable crashlogd properties
-persist.crashlogd.          u:object_r:crashlogd_prop:s0
+persist.vendor.crashlogd.          u:object_r:vendor_crashlogd_prop:s0

--- a/sepolicy/crashlogd/system_app.te
+++ b/sepolicy/crashlogd/system_app.te
@@ -2,7 +2,7 @@
 # system_app
 #
 
-get_prop(system_app, crashlogd_prop)
+get_prop(system_app, vendor_crashlogd_prop)
 
 allow system_app debugfs:dir r_dir_perms;
 

--- a/sepolicy/crashlogd/vendor_shell.te
+++ b/sepolicy/crashlogd/vendor_shell.te
@@ -1,5 +1,5 @@
 # enable the change of crashlog properties
 userdebug_or_eng(`
-  set_prop(shell, crashlogd_prop)
+  set_prop(vendor_shell, vendor_crashlogd_prop)
 ')
 

--- a/sepolicy/debug-logs/file.te
+++ b/sepolicy/debug-logs/file.te
@@ -1,1 +1,1 @@
-type log_file, mlstrustedobject, file_type;
+type log_file, mlstrustedobject, file_type, data_file_type, core_data_file_type;

--- a/sepolicy/debug-logs/logsvc.te
+++ b/sepolicy/debug-logs/logsvc.te
@@ -1,13 +1,14 @@
 # Rules for debug-logs specific services
-type logsvc, domain;
-type logsvc_exec, exec_type, file_type;
+type logsvc, domain, data_between_core_and_vendor_violators;
+type logsvc_exec, exec_type, file_type, vendor_file_type;
 
 init_daemon_domain(logsvc);
 
-permissive logsvc;
+userdebug_or_eng(`
+  permissive logsvc;
+')
 
 allow logsvc system_file:file x_file_perms;
-allow logsvc shell_exec:file rx_file_perms;
 
 dontaudit logsvc self:capability { dac_override sys_nice };
 allow logsvc self:capability2 syslog;
@@ -21,16 +22,23 @@ allow logsvc logd:unix_stream_socket connectto;
 allow logsvc kmsg_device:chr_file { open read };
 allow logsvc kernel:system syslog_read;
 
-set_prop(logsvc, system_prop)
 set_prop(logsvc, ctl_default_prop)
 
 allow logsvc logsvc_exec:file execute_no_trans;
 
-allow logsvc logcat_exec:file execute_no_trans;
-allow logsvc logcat_exec:file rx_file_perms;
-
 # Execute toolbox/toybox commands
-allow logsvc toolbox_exec:file rx_file_perms;
  
 allow logsvc cache_file:dir r_dir_perms;
 allow logsvc cache_file:file r_file_perms;
+
+not_full_treble(`
+  allow logsvc toolbox_exec:file rx_file_perms;
+  allow logsvc system_file:file x_file_perms;
+  allow logsvc shell_exec:file rx_file_perms;
+')
+
+full_treble_only(`
+  allow logsvc vendor_toolbox_exec:file rx_file_perms;
+  allow logsvc vendor_shell_exec:file rx_file_perms;
+')
+

--- a/sepolicy/debug-phonedoctor/file.te
+++ b/sepolicy/debug-phonedoctor/file.te
@@ -1,2 +1,2 @@
 # Always define since seapp contexts does not support m4 macro support.
-type crashreport_app_data_file, file_type, data_file_type, mlstrustedobject;
+type crashreport_app_data_file, file_type, data_file_type, core_data_file_type, mlstrustedobject;

--- a/sepolicy/debug-phonedoctor/system_app.te
+++ b/sepolicy/debug-phonedoctor/system_app.te
@@ -1,6 +1,3 @@
-# setprop ctl.logconfig
-set_prop(system_app, ctl_logconfig_prop)
-
 allow system_app sysfs_devices_system_cpu:file rw_file_perms;
 
 # com.intel.crashreport which is part of the crash_package used by phonedoctor


### PR DESCRIPTION
Due to treble enabling, some selinux rule may violate
google original selinux rule. We do some change in this
patch to make it is compatible with google original selinux
rule.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76202
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>
Signed-off-by: Ji, Zhenlong z <zhenlong.z.ji@intel.com>