### PR TITLE
Add target-level in manifest.xml

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device">
+<manifest version="1.0" type="device" target-level="3">
     <sepolicy>
         <version>27.0</version>
     </sepolicy>


### PR DESCRIPTION
Fix VTS test fail due to target-level is not specified in
device manifest.xml.

Tracked-On: OAM-75997
Signed-off-by: Bo Tong <bo.tong@intel.com>
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>