### PR TITLE
Add sepolicies for CTS failures seen in network related tests

### DIFF
--- a/sepolicy/te_macros
+++ b/sepolicy/te_macros
@@ -39,3 +39,5 @@ define(`ignore_adb_debug', `
     permissive $1;
   ')
 ')
+
+define(`user_build_only', ifelse(target_build_variant, `user', $1, ))

--- a/sepolicy/vendor/dnsmasq.te
+++ b/sepolicy/vendor/dnsmasq.te
@@ -1,0 +1,2 @@
+allow dnsmasq netd:fifo_file getattr;
+allow dnsmasq netd:unix_stream_socket getattr;

--- a/sepolicy/vendor/netd.te
+++ b/sepolicy/vendor/netd.te
@@ -1,0 +1,5 @@
+dontaudit netd kernel:system module_request;
+dontaudit netd self:capability sys_module;
+dontaudit netd system_file:dir write;
+
+allow netd system_server:icmp_socket { read write };

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -1,0 +1,4 @@
+allow system_server self:icmp_socket create_socket_perms_no_ioctl;
+
+dontaudit system_server self:capability sys_module;
+dontaudit system_server kernel:system syslog_read;

--- a/sepolicy/vendor/untrusted_app_all.te
+++ b/sepolicy/vendor/untrusted_app_all.te
@@ -1,0 +1,17 @@
+dontaudit untrusted_app_all mnt_vendor_file:dir search;
+dontaudit untrusted_app_all system_data_file:dir setattr;
+dontaudit untrusted_app_all sysfs_zram:dir search;
+dontaudit untrusted_app_all sysfs:dir r_dir_perms;
+dontaudit untrusted_app_all backup_data_file:dir r_dir_perms;
+dontaudit untrusted_app_all anr_data_file:dir r_dir_perms;
+allow untrusted_app_all vendor_file:file r_file_perms;
+allow untrusted_app_all fs_bpf:dir search;
+
+user_build_only(`
+   dontaudit untrusted_app_all block_device:dir getattr;
+   dontaudit untrusted_app_all configfs:dir search;
+   dontaudit untrusted_app_all kernel:dir search;
+   dontaudit untrusted_app_all proc_qtaguid_stat:file r_file_perms;
+   dontaudit untrusted_app_all qtaguid_proc:file r_file_perms;
+   dontaudit untrusted_app_all qtaguid_device:chr_file r_file_perms;
+')


### PR DESCRIPTION
- Added socket permissions for netd, system_server
- Add getattr permissions for dnsmask
- Add dontaudit for some of the reported sepolicy errors.
- Add user_build_only macro

Tracked-On: OAM-76271
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>