### PR TITLE
[CELADON] Allow mixin option for app launch boost

### DIFF
--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -56,7 +56,7 @@ art-config: default
 gptbuild: true(size=14G,generate_craff=false)
 device-type: car
 swap:zram(size=1073741824,swappiness=false,hardware=cel_kbl)
-power: true
+power: true(app_launch_boost=true)
 firststage-mount: true
 default-drm: true
 serialport: ttyS0


### PR DESCRIPTION
This mixin configuration allows to enable/disable
app launch boost with true/false values.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76682
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>