### PR TITLE
Kernel : Support USB serial console in APL NUC.

### DIFF
--- a/sepolicy/domain.te
+++ b/sepolicy/domain.te
@@ -1,1 +1,4 @@
 allow domain system_file:dir r_dir_perms;
+
+# Allow all domains read access to sysfs_thermal
+r_dir_file(domain, sysfs_thermal);

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,2 @@
+/sys/class/thermal(/.*)?                             u:object_r:sysfs_thermal:s0
+/sys/module/thermal(/.*)?                            u:object_r:sysfs_thermal:s0


### PR DESCRIPTION
 Kernel : Support USB serial console in APL NUC.

  1.Enable the USB serial console.
  2.Set apl_nuc lunch target use USB serial console,and the others use the default ttyS0.
  3.Only support FTDI USB serial convertor now.

Tracked-On: OAM-76637
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>