### PR TITLE
Sepolicy : Enable /sys/class/thermal access permission.

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,2 @@
+/sys/class/thermal(/.*)?                                 u:object_r:sysfs_thermal:s0
+/sys/module/thermal(/.*)?                                u:object_r:sysfs_thermal:s0

--- a/sepolicy/shell.te
+++ b/sepolicy/shell.te
@@ -2,3 +2,8 @@ allow shell efs_file:dir search;
 allow shell efs_file:file r_file_perms;
 allow shell bluetooth_efs_file:dir search;
 allow shell bluetooth_efs_file:file r_file_perms;
+
+# Allow shell read access to sysfs_thermal
+recovery_only(`
+r_dir_file(shell, sysfs_thermal);
+')


### PR DESCRIPTION
When do adb sideload in recovery mode, there is an error "E: Failed to
scandir /sys/class/thermal/: Permission denied".There is enable the file
access permission with SElinux sepolicy.

Tracked-On: OAM-76587
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>