### PR TITLE
thermal-daemon: Fix sepolicy violation on vendor data file

### DIFF
--- a/sepolicy/thermal/thermal-daemon/vendor_init.te
+++ b/sepolicy/thermal/thermal-daemon/vendor_init.te
@@ -1,7 +1,7 @@
 allow vendor_init sysfs_powercap:dir r_dir_perms;
 allow vendor_init sysfs_powercap:file { read setattr };
 allow vendor_init thermal-daemon_data_file: dir r_dir_perms;
-allow vendor_init thermal-daemon_data_file: file { read setattr };
+allow vendor_init thermal-daemon_data_file: file { read };
 allow vendor_init thermal-daemon_run_dir: dir create_dir_perms;
 allow vendor_init thermal-daemon_run_dir: file { create read write setattr };
 allow vendor_init sysfs_dmi_id: file { read setattr };


### PR DESCRIPTION
setattr on vendor data file (/vendor/etc/thermal-daemon) partition is
neverallow. Fixing this error.

Tracked-On: OAM-77695
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>