### PR TITLE
thermal-daemon: Fix sepolicy error on thermal sysfs link files

### DIFF
--- a/sepolicy/thermal/thermal-daemon/thermal-daemon.te
+++ b/sepolicy/thermal/thermal-daemon/thermal-daemon.te
@@ -15,6 +15,7 @@ allow thermal-daemon sysfs_powercap:{ file lnk_file } rw_file_perms;
 allow thermal-daemon sysfs_powercap:dir r_dir_perms;
 allow thermal-daemon sysfs_thermal:dir r_dir_perms;
 allow thermal-daemon sysfs_thermal:file rw_file_perms;
+allow thermal-daemon sysfs_thermal:lnk_file read;
 allow thermal-daemon sysfs_leds:dir r_dir_perms;
 allow thermal-daemon sysfs_leds:file rw_file_perms;
 allow thermal-daemon sysfs_backlight_thermal:dir r_dir_perms;


### PR DESCRIPTION
avc error for read permission was thrown on thermal sysfs link
files. This change fixes the errors.

Tracked-On: OAM-77806
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>