### PR TITLE
Add Telephony TX and RX devices

### DIFF
--- a/common/audio/default/policy/audio_policy_configuration.xml
+++ b/common/audio/default/policy/audio_policy_configuration.xml
@@ -24,6 +24,8 @@
             <attachedDevices>
                 <item>Speaker</item>
                 <item>Built-In Mic</item>
+                <item>Telephony Tx</item>
+                <item>Telephony Rx</item>
             </attachedDevices>
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
@@ -43,6 +45,14 @@
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000"
                              channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+                </mixPort>
+                <mixPort name="voice_rx" role="sink">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="8000,16000,48000" channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+                </mixPort>
+                <mixPort name="voice_tx" role="source">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="8000,16000,48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
             </mixPorts>
 
@@ -78,6 +88,9 @@
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="32000,44100,48000"/>
                 </devicePort>
+
+                <devicePort tagName="Telephony Tx" type="AUDIO_DEVICE_OUT_TELEPHONY_TX" role="sink"/>
+                <devicePort tagName="Telephony Rx" type="AUDIO_DEVICE_IN_TELEPHONY_RX" role="source"/>
             </devicePorts>
             <!-- route declaration, i.e. list all available sources for a given sink -->
             <routes>
@@ -91,6 +104,10 @@
                        sources="hdmi_stereo,hdmi_multi"/>
                 <route type="mix" sink="primary_input"
                        sources="Wired Headset Mic,Built-In Mic"/>
+                <route type="mix" sink="voice_rx"
+                       sources="Telephony Rx"/>
+                <route type="mix" sink="Telephony Tx"
+                       sources="voice_tx"/>
             </routes>
 
         </module>


### PR DESCRIPTION
On CEL call devices are on USB Audio HAL, so APM expects to create
telephony rx & tx patches, for this vendor configs should have entries
for respective virtual devices and mixports.

Signed-off-by: Karan Patidar <karan.patidar@intel.com>