### PR TITLE
Debug: remove some rules of data_between_core_and_vendor_violators

### DIFF
--- a/sepolicy/crashlogd/dumpstate.te
+++ b/sepolicy/crashlogd/dumpstate.te
@@ -1,4 +1,3 @@
 allow dumpstate block_device:blk_file getattr;
 allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate kernel:system module_request;
 allow dumpstate self:netlink_xfrm_socket create;

--- a/sepolicy/debug-logs/logsvc.te
+++ b/sepolicy/debug-logs/logsvc.te
@@ -8,8 +8,6 @@ userdebug_or_eng(`
   permissive logsvc;
 ')
 
-allow logsvc system_file:file x_file_perms;
-
 dontaudit logsvc self:capability { dac_override sys_nice };
 allow logsvc self:capability2 syslog;
 
@@ -33,7 +31,6 @@ allow logsvc cache_file:file r_file_perms;
 
 not_full_treble(`
   allow logsvc toolbox_exec:file rx_file_perms;
-  allow logsvc system_file:file x_file_perms;
   allow logsvc shell_exec:file rx_file_perms;
 ')
 


### PR DESCRIPTION
1, "allow logsvc system_file:file x_file_perms": This access was
used to allow the script of logsvc to run /system/bin/logcat tool
to generate aplog, however, logsvc is permissive currently, so remove
it will not impact functionality.
2, "allow dumpstate kernel:system module_request": This dumpstate is an
AOSP tool.

Tracked-On: OAM-79591
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>