### PR TITLE
Debug: remove some rules of data_between_core_and_vendor_violators

### DIFF
--- a/sepolicy/crashlogd/dumpstate.te
+++ b/sepolicy/crashlogd/dumpstate.te
@@ -1,4 +1,3 @@
 allow dumpstate block_device:blk_file getattr;
 allow dumpstate debugfs_graphics_sync:dir r_dir_perms;
-allow dumpstate kernel:system module_request;
 allow dumpstate self:netlink_xfrm_socket create;

--- a/sepolicy/debug-logs/logsvc.te
+++ b/sepolicy/debug-logs/logsvc.te
@@ -1,5 +1,5 @@
 # Rules for debug-logs specific services
-type logsvc, domain, data_between_core_and_vendor_violators;
+type logsvc, domain;
 type logsvc_exec, exec_type, file_type, vendor_file_type;
 
 init_daemon_domain(logsvc);
@@ -8,37 +8,34 @@ userdebug_or_eng(`
   permissive logsvc;
 ')
 
-allow logsvc system_file:file x_file_perms;
-
 dontaudit logsvc self:capability { dac_override sys_nice };
-allow logsvc self:capability2 syslog;
+dontaudit logsvc self:capability2 syslog;
 
-allow logsvc log_file:file create_file_perms;
-allow logsvc log_file:dir rw_dir_perms;
+dontaudit logsvc log_file:file create_file_perms;
+dontaudit logsvc log_file:dir rw_dir_perms;
 
-allow logsvc logdr_socket:sock_file write;
-allow logsvc logd:unix_stream_socket connectto;
+dontaudit logsvc logdr_socket:sock_file write;
+dontaudit logsvc logd:unix_stream_socket connectto;
 
-allow logsvc kmsg_device:chr_file { open read };
-allow logsvc kernel:system syslog_read;
+dontaudit logsvc kmsg_device:chr_file { open read };
+dontaudit logsvc kernel:system syslog_read;
 
 set_prop(logsvc, ctl_default_prop)
 
-allow logsvc logsvc_exec:file execute_no_trans;
+dontaudit logsvc logsvc_exec:file execute_no_trans;
 
 # Execute toolbox/toybox commands
  
-allow logsvc cache_file:dir r_dir_perms;
-allow logsvc cache_file:file r_file_perms;
+dontaudit logsvc cache_file:dir r_dir_perms;
+dontaudit logsvc cache_file:file r_file_perms;
 
 not_full_treble(`
-  allow logsvc toolbox_exec:file rx_file_perms;
-  allow logsvc system_file:file x_file_perms;
-  allow logsvc shell_exec:file rx_file_perms;
+  dontaudit logsvc toolbox_exec:file rx_file_perms;
+  dontaudit logsvc shell_exec:file rx_file_perms;
 ')
 
 full_treble_only(`
-  allow logsvc vendor_toolbox_exec:file rx_file_perms;
-  allow logsvc vendor_shell_exec:file rx_file_perms;
+  dontaudit logsvc vendor_toolbox_exec:file rx_file_perms;
+  dontaudit logsvc vendor_shell_exec:file rx_file_perms;
 ')
 


### PR DESCRIPTION
1, "allow logsvc system_file:file x_file_perms": This access was
used to allow the script of logsvc to run /system/bin/logcat tool
to generate aplog, however, logsvc is permissive currently, so remove
it will not impact functionality.
2, remove data_between_core_and_vendor_violators attributes, and change
related rules as dontaudit due to logsvc is permissive.
3, "allow dumpstate kernel:system module_request": This dumpstate is an
AOSP tool.

Tracked-On: OAM-79591
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>