### PR TITLE
Modify Audio Encoder profiles

### DIFF
--- a/common/media/media_profiles.xml
+++ b/common/media/media_profiles.xml
@@ -454,18 +454,18 @@
 
     <AudioEncoderCap name="aac" enabled="true"
         minBitRate="5525" maxBitRate="250000"
-        minSampleRate="8000" maxSampleRate="44100"
-        minChannels="1" maxChannels="1" />
+        minSampleRate="8000" maxSampleRate="48000"
+        minChannels="1" maxChannels="2" />
 
     <AudioEncoderCap name="heaac" enabled="true"
         minBitRate="8000" maxBitRate="64000"
         minSampleRate="16000" maxSampleRate="48000"
-        minChannels="1" maxChannels="1" />
+        minChannels="1" maxChannels="2" />
 
     <AudioEncoderCap name="aaceld" enabled="true"
         minBitRate="16000" maxBitRate="192000"
         minSampleRate="16000" maxSampleRate="48000"
-        minChannels="1" maxChannels="1" />
+        minChannels="1" maxChannels="2" />
 
     <!--
         FIXME:


### PR DESCRIPTION
AudioEncoder profiles are updated to use maxChannels as 2 for heaac & aaceld.
aac profile updated to use maxSampleRate as 48000

Tracked-On: OAM-71786
Signed-off-by: Karan Patidar <karan.patidar@intel.com>