### PR TITLE
Add a rule to allow HWC access /vendor/hwc.lock

### DIFF
--- a/sepolicy/graphics/mesa/hal_graphics_composer_default.te
+++ b/sepolicy/graphics/mesa/hal_graphics_composer_default.te
@@ -16,3 +16,4 @@ allow hal_graphics_composer_default gpu_device:dir r_dir_perms;
 allow hal_graphics_composer_default gpu_device:chr_file rw_file_perms;
 allow hal_graphics_composer_default sysfs_app_readable:file r_file_perms;
 allow hal_graphics_composer_default hwc_info_service:service_manager add;
+allow hal_graphics_composer_default vendor_file:file r_file_perms;


### PR DESCRIPTION
A read rule is added to allow HWC access /vendor/hwc.lock

Tracked-On: https://jira.devtools.intel.com/browse/OAM-79203
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>