### PR TITLE
SEPolicy: Refine sepolicy rules basing on requirements of PSE

### DIFF
--- a/sepolicy/config-partition/ueventd.te
+++ b/sepolicy/config-partition/ueventd.te
@@ -1,6 +1,0 @@
-#
-# ueventd
-#
-typeattribute ueventd data_between_core_and_vendor_violators;
-allow ueventd config_file:dir search;
-allow ueventd config_file:file r_file_perms;

--- a/sepolicy/config-partition/vold.te
+++ b/sepolicy/config-partition/vold.te
@@ -1,7 +1,0 @@
-#
-# vold
-#
-typeattribute vold data_between_core_and_vendor_violators;
-allow vold config_file:dir r_dir_perms;
-# uapi/linux/fs.h:#define FITRIM _IOWR('X', 121, struct fstrim_range) /* Trim */
-#allow vold config_file:dir 0x5879;

--- a/sepolicy/kernel/appdomain.te
+++ b/sepolicy/kernel/appdomain.te
@@ -1,1 +1,0 @@
-allow appdomain self:icmp_socket create_socket_perms_no_ioctl;

--- a/sepolicy/kernel/netd.te
+++ b/sepolicy/kernel/netd.te
@@ -1,4 +1,0 @@
-allow netd kernel:system module_request;
-allow netd self:capability { sys_module fsetid };
-allow netd untrusted_app:icmp_socket {read write getopt setopt getattr};
-

--- a/sepolicy/kernel/ueventd.te
+++ b/sepolicy/kernel/ueventd.te
@@ -1,4 +1,0 @@
-allow ueventd self:capability sys_module;
-allow ueventd vendor_file:system module_load;
-allow ueventd kernel:key search;
-allow ueventd kernel:system module_request;

--- a/sepolicy/thermal/thermal-daemon/thermal-daemon.te
+++ b/sepolicy/thermal/thermal-daemon/thermal-daemon.te
@@ -2,7 +2,7 @@
 # thermal-daemon
 #
 
-type thermal-daemon, domain, data_between_core_and_vendor_violators;
+type thermal-daemon, domain;
 type thermal-daemon_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(thermal-daemon)
 

--- a/sepolicy/vendor/netd.te
+++ b/sepolicy/vendor/netd.te
@@ -1,5 +1,3 @@
 dontaudit netd kernel:system module_request;
 dontaudit netd self:capability sys_module;
 dontaudit netd system_file:dir write;
-
-allow netd system_server:icmp_socket { read write };

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -1,4 +1,2 @@
-allow system_server self:icmp_socket create_socket_perms_no_ioctl;
-
 dontaudit system_server self:capability sys_module;
 dontaudit system_server kernel:system syslog_read;


### PR DESCRIPTION
1. Remove icmp_socket related rules, use AOSP patch instead
2. Remove some data_between_system_and_vendor_violators

Tracked-On: OAM-79592
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>