### PR TITLE
Revert "add neural network GPU hal support"

### DIFF
--- a/cel_apl/manifest.xml
+++ b/cel_apl/manifest.xml
@@ -193,14 +193,13 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.neuralnetworks</name>
-        <transport>hwbinder</transport>
-        <version>1.1</version>
-        <interface>
-            <name>IDevice</name>
-            <instance>CPU</instance>
-            <instance>gpgpu</instance>
-        </interface>
+          <name>android.hardware.neuralnetworks</name>
+          <transport>hwbinder</transport>
+          <version>1.1</version>
+          <interface>
+              <name>IDevice</name>
+              <instance>CPU</instance>
+          </interface>
     </hal>
     <hal format="hidl">
         <name>android.hardware.health</name>


### PR DESCRIPTION
This reverts commit 1022f2eca062906ebcf9848be95b50b5aaf28fc0.
GPGPU HAL is not ready to pass VTS test.