### PR TITLE
Thermal: [WA][Revert Me] disable WHL thermal shutdown

### DIFF
--- a/common/thermal/thermal-conf.xml
+++ b/common/thermal/thermal-conf.xml
@@ -179,7 +179,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>85000</Temperature>
+						<Temperature>75000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -192,16 +192,6 @@
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
 						</CoolingDevice>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
-						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
 			</ThermalZone>


### PR DESCRIPTION
It's found SOC temperature in WHL RVP could be sharply increased from ~45C to 100C within 2~3s
when GPU/CPU has higher load. It results in thermal shutdown
at last for example in boot-up or switching user account.

This patch disables the thermal shutdown as a work around solution considering
no hardware is available for thermal team to do fine thermal parameters tunning.

Tracked-On: OAM-79843
Signed-off-by: Zhen Han <zhen.han@intel.com>