### PR TITLE
Revert "add neural network GPU hal support" for kbl/celadon/clk

### DIFF
--- a/cel_kbl/manifest.xml
+++ b/cel_kbl/manifest.xml
@@ -199,7 +199,6 @@
         <interface>
             <name>IDevice</name>
             <instance>CPU</instance>
-            <instance>gpgpu</instance>
         </interface>
     </hal>
     <hal format="hidl">

--- a/celadon/manifest.xml
+++ b/celadon/manifest.xml
@@ -199,7 +199,6 @@
         <interface>
             <name>IDevice</name>
             <instance>CPU</instance>
-            <instance>gpgpu</instance>
         </interface>
     </hal>
     <hal format="hidl">

--- a/clk/manifest.xml
+++ b/clk/manifest.xml
@@ -199,7 +199,6 @@
         <interface>
             <name>IDevice</name>
             <instance>CPU</instance>
-            <instance>gpgpu</instance>
         </interface>
     </hal>
     <hal format="hidl">


### PR DESCRIPTION
This reverts commit 1022f2eca062906ebcf9848be95b50b5aaf28fc0.
Due to manifest.xml is made specific to different platform, previous
revert only applied to apl platform.
GPGPU HAL is not ready to pass VTS test.

Tracked-On: OAM-80053
Signed-off-by: Fei Jiang <fei.jiang@intel.com>