### PR TITLE
[DO NOT MERGE]cel_apl: use ttyS0 instead of ttyUSB0.

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -59,5 +59,5 @@ swap:zram(size=1073741824,swappiness=false,hardware=cel_apl)
 power: true
 firststage-mount: true
 default-drm: true
-serialport: ttyUSB0
+serialport: ttyS0
 neuralnetworks: true


### PR DESCRIPTION
Signed-off-by: Ming Tan <ming.tan@intel.com>