### PR TITLE
add support for Iris driver

### DIFF
--- a/sepolicy/graphics/mesa/file_contexts
+++ b/sepolicy/graphics/mesa/file_contexts
@@ -13,6 +13,8 @@
 /(vendor|system/vendor)/lib(64)?/libdrm_intel_pri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/gralloc\.project-celadon\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/dri/i965_dri\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/dri/iris_dri\.so u:object_r:same_process_hal_file:s0
+/(vendor|system/vendor)/lib(64)?/dri/gallium_dri\.so u:object_r:same_process_hal_file:s0
 /(vendor|system/vendor)/lib(64)?/hw/vulkan\.project-celadon\.so u:object_r:same_process_hal_file:s0
 /vendor/bin/hw/android\.hardware\.graphics\.composer\.allocator@2\.1-service u:object_r:hal_graphics_composer_default_exec:s0
 /(vendor|system/vendor)/lib(64)?/libdrm_intel\.so u:object_r:same_process_hal_file:s0

--- a/sepolicy/graphics/mesa/platform_app.te
+++ b/sepolicy/graphics/mesa/platform_app.te
@@ -28,4 +28,8 @@ allowxperm platform_app gpu_device:chr_file ioctl {
 	DRM_IOCTL_I915_REG_READ
 	DRM_IOCTL_I915_GEM_MMAP_GTT
 	0x6475
+	0x6474
+	0x64bf
+	0x64c0
+	0x64c3
 };

--- a/sepolicy/graphics/mesa/surfaceflinger.te
+++ b/sepolicy/graphics/mesa/surfaceflinger.te
@@ -29,4 +29,9 @@ allowxperm surfaceflinger gpu_device:chr_file ioctl {
 	DRM_IOCTL_MODE_GETPROPERTY
 	DRM_IOCTL_I915_GEM_WAIT
 	0x6475
+	0x6474
+	0x64c3
+	0x64c1
+	0x64bf
+	0x64c0
 };


### PR DESCRIPTION
This driver requires additional ioctls, these same ones are also
required by the anv vulkan driver.

Jira: None
Signed-off-by: Tapani Pälli <tapani.palli@intel.com>