### PR TITLE
neuralnetworks: Add sepolicy to read vendor property

### DIFF
--- a/sepolicy/neuralnetworks/hal_neuralnetworks.te
+++ b/sepolicy/neuralnetworks/hal_neuralnetworks.te
@@ -18,6 +18,8 @@ allow hal_neuralnetworks_default usb_device:chr_file rw_file_perms;
 allow hal_neuralnetworks_default self:netlink_kobject_uevent_socket { read bind create setopt };
 
 dontaudit hal_neuralnetworks_default self:capability { dac_read_search dac_override };
+
+get_prop(hal_neuralnetworks_default, vendor_nnhal_prop)
 allow hal_neuralnetworks_default sysfs:dir r_dir_perms;
 allow hal_neuralnetworks_default sysfs:file rw_file_perms;
 allow hal_neuralnetworks_default nn_vendor_data_file:dir rw_dir_perms;

--- a/sepolicy/neuralnetworks/property.te
+++ b/sepolicy/neuralnetworks/property.te
@@ -1,0 +1,1 @@
+type vendor_nnhal_prop, property_type;

--- a/sepolicy/neuralnetworks/property_contexts
+++ b/sepolicy/neuralnetworks/property_contexts
@@ -1,0 +1,1 @@
+persist.vendor.nn_hal.    u:object_r:vendor_nnhal_prop:s0


### PR DESCRIPTION
Sepolicy added for neural networks to read vendor
property persist.vendor.nn_hal.disable

Tracked-On: OAM-83304
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>