### PR TITLE
Add keybox_provision parameter for cel_kbl boot-arch

### DIFF
--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -61,3 +61,4 @@ firststage-mount: true
 default-drm: true
 serialport: ttyS0
 neuralnetworks: true
+keybox_provision = false


### PR DESCRIPTION
if keybox_provision is true, we can support trusty keybox
provision using fastboot command, default value is false.