### PR TITLE
add keybox_provision parameter in kbl mixins.spec

### DIFF
--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -61,3 +61,4 @@ firststage-mount: true
 default-drm: true
 serialport: ttyS0
 neuralnetworks: true
+keybox_provision: false


### PR DESCRIPTION
if keybox_provision is true, we can support trusty keybox
provision using fastboot command, default value is false.

Signed-off-by: gli41 <genshen.li@intel.com>
Tracked-On: OAM-83317