### PR TITLE
refine trusty flags for celadon

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -43,7 +43,7 @@ debug-phonedoctor: true
 debug-tools: true
 flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true,timeout=7200000)
 midi: true
-trusty: true(enable_hw_sec=true,enable_storage_proxyd=true,ref_target=project-celadon_apl)
+trusty: true(ref_target=celadon_apl)
 slcan: default
 ioc-slcan-reboot: false
 camera-ext: ext-camera-only

--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -43,7 +43,7 @@ debug-phonedoctor: true
 debug-tools: true
 flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true,timeout=7200000)
 midi: true
-trusty: true(enable_hw_sec=true,enable_storage_proxyd=true,ref_target=project-celadon_kbl)
+trusty: true(ref_target=celadon_kbl)
 slcan: default
 ioc-slcan-reboot: false
 camera-ext: ext-camera-only

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -44,7 +44,7 @@ debug-phonedoctor: true
 debug-tools: true
 flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true,timeout=7200000)
 midi: true
-trusty: true(enable_hw_sec=true,enable_storage_proxyd=true,ref_target=project-celadon_64)
+trusty: true(ref_target=celadon_64)
 slcan: default
 ioc-slcan-reboot: false
 camera-ext: ext-camera-only

--- a/clk/mixins.spec
+++ b/clk/mixins.spec
@@ -44,7 +44,7 @@ debug-phonedoctor: true
 debug-tools: true
 flashfiles: ini(oemvars=false,version=3.0,fastboot_min_battery_level=false,installer=true,timeout=7200000)
 midi: true
-trusty: true(ref_target=project-celadon_clk)
+trusty: true(ref_target=celadon_clk)
 slcan: default
 ioc-slcan-reboot: false
 camera-ext: ext-camera-only


### PR DESCRIPTION
The default value of enable_hw_sec and enable_storage_proxyd are ture.
No need to define them in mixins.spec.
Change trusty ref_target name from project-celadon_xxx to celadon_xxx.

Tracked-On: OAM-84127
Signed-off-by: sheng wei <w.sheng@intel.com>