### PR TITLE
Sepolicy: Add a label for rtc

### DIFF
--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -1,0 +1,2 @@
+# sysfs
+genfscon sysfs /devices/pnp0/00:04/rtc   u:object_r:sysfs_rtc:s0


### PR DESCRIPTION
Fix avc denied issue to create genfs_contexts in directory
vendor and increase permission in genfs_contexts by adding
label.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>