### PR TITLE
[CELADON] Add EFI shell as part of celadon flashfiles

### DIFF
--- a/cel_apl/mixins.spec
+++ b/cel_apl/mixins.spec
@@ -61,3 +61,4 @@ firststage-mount: true
 default-drm: true
 serialport: ttyUSB0
 neuralnetworks: true
+internal-efishell: true

--- a/cel_kbl/mixins.spec
+++ b/cel_kbl/mixins.spec
@@ -61,3 +61,4 @@ firststage-mount: true
 default-drm: true
 serialport: ttyS0
 neuralnetworks: true
+internal-efishell: true

--- a/celadon/mixins.spec
+++ b/celadon/mixins.spec
@@ -61,3 +61,4 @@ firststage-mount: true
 serialport: ttyS0
 default-drm: true
 neuralnetworks: true
+internal-efishell: true

--- a/clk/mixins.spec
+++ b/clk/mixins.spec
@@ -60,3 +60,4 @@ power: true
 firststage-mount: true
 serialport: ttyS0
 default-drm: true
+internal-efishell: true


### PR DESCRIPTION
Add EFI shell as part of celadon flashfiles that enables automatic boot to shell on platforms without internal EFI shell support.
Created new mixin group internal-efishell.

Tracked-On: OAM-84428
Signed-off: debarghy <debarghya.bhattacharya@intel.com>