### PR TITLE
Include Wifi firmware for Intel connectivity modules

### DIFF
--- a/common/firmware.mk
+++ b/common/firmware.mk
@@ -19,14 +19,7 @@
 LOCAL_FIRMWARE_SRC := \
     i6050-fw-usb-1.5.sbcf \
     i2400m-fw-usb-1.4.sbcf \
-    i2400m-fw-usb-1.5.sbcf \
-    iwlwifi-3168-29.ucode \
-    iwlwifi-8265-31.ucode \
-    iwlwifi-9000-pu-b0-jf-b0-38.ucode \
-    iwlwifi-9000-pu-b0-jf-b0-41.ucode \
-    iwlwifi-9260-th-b0-jf-b0-38.ucode \
-    iwlwifi-9260-th-b0-jf-b0-41.ucode \
-    iwlwifi-9260-th-b0-jf-b0-43.ucode
+    i2400m-fw-usb-1.5.sbcf
 
 ## List of complete Firmware folders to be copied
 
@@ -36,8 +29,8 @@ LOCAL_FIRMWARE_DIR := \
 
 ## List of matching patterns of Firmware bins to be copied
 
-#LOCAL_FIRMWARE_PATTERN := \
-#    iwlwifi
+LOCAL_FIRMWARE_PATTERN := \
+    iwlwifi
 
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN),$(shell cd $(FIRMWARES_DIR) && find . -iname "*$(f)*" -type f ))
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_DIR),$(shell cd $(FIRMWARES_DIR) && find $(f) -type f) )


### PR DESCRIPTION
This reverts commit c47c8a3df3889c3868954addb1634e4a2f9ab3f1 and
e643728eea6dcbab2ddb73e373e07526537facba.

By reverting this commits, firmwares for all Intel Wifi
modules are included as part of the image.

Tracked-On: CEL-692
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>