### PR TITLE
Enable the default DRM

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -82,3 +82,4 @@ dbc: true
 atrace: true
 firmware: true
 evs: true
+default-drm: true


### PR DESCRIPTION
CTS reqiures feature DRM, so enable the default one.

Tracked-On: OAM-84905
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>