### PR TITLE
EM: Update power profile

### DIFF
--- a/celadon_ivi/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/celadon_ivi/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -63,6 +63,28 @@
       <value>4</value> <!-- cluster 0 has cpu0, cpu1, cpu2, cpu3 -->
   </array>
 
+  <!-- Additional power used by a CPU core from cluster 0 when running at
+       different speeds, excluding cluster and active cost -->
+  <array name="cpu.core_power.cluster0">
+      <value>8</value> <!-- 800 MHz CPU speed -->
+      <value>9</value> <!-- 900 MHz CPU speed -->
+      <value>10</value> <!-- 1000 MHz CPU speed -->
+      <value>11</value> <!-- 1100 MHz CPU speed -->
+      <value>12</value> <!-- 1200 MHz CPU speed -->
+      <value>13</value> <!-- 1300 MHz CPU speed -->
+      <value>14</value> <!-- 1400 MHz CPU speed -->
+      <value>15</value> <!-- 1500 MHz CPU speed -->
+      <value>16</value> <!-- 1600 MHz CPU speed -->
+      <value>17</value> <!-- 1700 MHz CPU speed -->
+      <value>18</value> <!-- 1800 MHz CPU speed -->
+      <value>19</value> <!-- 1900 MHz CPU speed -->
+      <value>20</value> <!-- 2000 MHz CPU speed -->
+      <value>21</value> <!-- 2100 MHz CPU speed -->
+      <value>22</value> <!-- 2200 MHz CPU speed -->
+      <value>23</value> <!-- 2300 MHz CPU speed -->
+      <value>24</value> <!-- 2400 MHz CPU speed -->
+  </array>
+  
     <!-- Different CPU speeds for cluster 0 as reported in
        /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state.
 
@@ -110,6 +132,9 @@
       <value>1630</value>  <!-- current when CPU speed is 2300MHz -->
       <value>1630</value>  <!-- current when CPU speed is 2400MHz -->
   </array>
+
+  <!-- Current when CPU is active -->
+  <item name="cpu.active">1000</item>
 
   <!-- Current when CPU is idle -->
   <item name="cpu.idle">190</item>


### PR DESCRIPTION
"cpu.core_power.cluster0" is a new power profile domain and used to
caculate cpu power usage by BatteryStatsHelper.java.

This patch adds this power profile for GP IVI.
NOTE: the current values are fake data as no real battery in GP MRB.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-86942
Signed-off-by: Sun Xinx <xinx.sun@intel.com>