### PR TITLE
Enable guc/huc on CIC.

### DIFF
--- a/cic/mixins.spec
+++ b/cic/mixins.spec
@@ -17,3 +17,4 @@ device-specific: cic
 graphics: aic_mdc
 usb: acc
 wlan: mac80211_hwsim
+graphics: mesa(gen9+=true,hwc2=true,vulkan=true,drmhwc=false,minigbm=true,gralloc1=true,enable_guc=true)


### PR DESCRIPTION
Guc is enabled to perform graphics workload scheduling, huc is enabled
to offload some of the media functions from CPU to GPU.