### PR TITLE
caas: Set media profile name in codecs mixins to support 1080p

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -29,7 +29,7 @@ ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
 wlan: auto
-codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt)
+codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt, profile_file=media_profiles_1080p.xml)
 codec2: true
 usb: host
 usb-gadget: configfs(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.0.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)


### PR DESCRIPTION
Set media profiles file name to media_profiles_1080p.xml
to support 720p and 1080p video recording.

Tracked-On: OAM-88630
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>