### PR TITLE
add guest id for aiv that will be used by the vsock

### DIFF
--- a/caas/start_android_qcow2.sh
+++ b/caas/start_android_qcow2.sh
@@ -59,6 +59,7 @@ common_options="\
  -audiodev id=android_spk,timer-period=5000,driver=pa \
  -drive file=$caas_image,if=none,id=disk1 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
+ -device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=3 \
  -device e1000,netdev=net0 \
  -netdev user,id=net0,hostfwd=tcp::5555-:5555,hostfwd=tcp::5554-:5554 \
  -device intel-iommu,device-iotlb=off,caching-mode=on \


### PR DESCRIPTION
the host id is a well known value(2), and we set the aiv's
guest id is 3, which will be used in the vsock connection.

Tracked-On: OAM-89561
Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>