### PR TITLE
adb: usb: adb over usb in recovery mode.

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -32,7 +32,7 @@ wlan: auto
 codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt, profile_file=media_profiles_1080p.xml)
 codec2: true
 usb: host
-usb-gadget: configfs(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.0.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)
+usb-gadget: configfs(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.1.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)
 midi: true
 touch: cvt0f21
 navigationbar: true


### PR DESCRIPTION
changed the dwc3 device name, earlier it was dwc3.0.auto
now it's dwc3.1.auto

Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>