### PR TITLE
mixin updates

### DIFF
--- a/caas/start_android_qcow2.sh
+++ b/caas/start_android_qcow2.sh
@@ -56,7 +56,7 @@ common_options="\
  -chardev socket,id=charserial0,path=./kernel-console,server,nowait \
  -device isa-serial,chardev=charserial0,id=serial0 \
  -device intel-hda -device hda-duplex \
- -audiodev id=android_spk,timer-period=5000,driver=pa \
+ -audiodev id=android_spk,timer-period=5000,server=$XDG_RUNTIME_DIR/pulse/native,driver=pa \
  -drive file=$caas_image,if=none,id=disk1 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -device e1000,netdev=net0 \


### PR DESCRIPTION
Kernel rebase to 4.19.107 on caas

Tracked-On: OAM-90300
Mixin-Reviewed-On: https://github.com/projectceladon/device-androidia-mixins/pull/529
Signed-off-by: rnaidu <ramya.v.naidu@intel.com>