### PR TITLE
[Debugging] For supporting ICL add a kernel parameter.

### DIFF
--- a/caas/BoardConfig.mk
+++ b/caas/BoardConfig.mk
@@ -241,7 +241,8 @@ BOARD_KERNEL_CMDLINE += \
 	reboot_panic=p,w \
 	i915.hpd_sense_invert=0x7 \
 	intel_iommu=off \
-	i915.enable_pvmmio=0
+	i915.enable_pvmmio=0 \
+	i915.enable_fbc=0
 
 BOARD_FLASHFILES += ${TARGET_DEVICE_DIR}/bldr_utils.img:bldr_utils.img
 BOARD_FLASHFILES += $(PRODUCT_OUT)/LICENSE


### PR DESCRIPTION
Add "i915.enable_fbc=0" for kernel to check if it can fix
the issue in GVT-d.

Tracked-On: None