### PR TITLE
Pass libwifi-hal to true for wlan mixins

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -30,7 +30,7 @@ storage: sdcard-mmc0-v-usb-sd(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
-wlan: auto
+wlan: auto(libwifi-hal=true)
 codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt, profile_file=media_profiles_1080p.xml)
 codec2: true
 usb: host


### PR DESCRIPTION
Wi-Fi direct is not working as libwifi-hal is not enabled.

Tracked-On: OAM-91329
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>