### PR TITLE
Health Hal: Enable sepolicy for health HAL intel.

### DIFF
--- a/sepolicy/hal_health_default.te
+++ b/sepolicy/hal_health_default.te
@@ -1,0 +1,1 @@
+allow hal_health_default sysfs:file r_file_perms;


### PR DESCRIPTION
This patch will enable sepolicy permission for intel health HAL.

Tracked-On: OAM-91263
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>