### PR TITLE
Extend caas image size to 32GB

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -77,7 +77,7 @@ disk-encryption: true
 factory-scripts: true
 filesystem_config: common
 load_modules: true
-gptbuild: true(size=16G,generate_craff=false,compress_gptimage=true)
+gptbuild: true(size=32G,generate_craff=false,compress_gptimage=true)
 dynamic-partitions: true(super_img_in_flashzip=true)
 dbc: true
 atrace: true


### PR DESCRIPTION

Extend caas image size to 32GB to meet requirement of CTS/GTS

Tracked-On: OAM-91483
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>