### PR TITLE
Disable suspend for CIC in mixin spec

### DIFF
--- a/cic/mixins.spec
+++ b/cic/mixins.spec
@@ -29,3 +29,4 @@ camera-ext: ext-camera-only
 bluetooth: cic
 storage: sdcard-mmc0-usb-sd(adoptablesd=false,adoptableusb=false)
 debug-crashlogd: true
+suspend: never


### PR DESCRIPTION
The device will never go to sleep since
we always have wakelock in the Android Framework.

Tracked-On: OAM-91468
Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
Signed-off-by: Shwetha B <shwetha.b@intel.com>