### PR TITLE
mixin updates

### DIFF
--- a/cic/mixins.spec
+++ b/cic/mixins.spec
@@ -27,6 +27,6 @@ codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=
 codec2: true
 camera-ext: ext-camera-only
 bluetooth: cic
-storage: sdcard-mmc0-usb-sd(adoptablesd=false,adoptableusb=false)
+storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=true)
 debug-crashlogd: true
 suspend: never

--- a/cic_dev/mixins.spec
+++ b/cic_dev/mixins.spec
@@ -25,4 +25,4 @@ codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=
 codec2: true
 camera-ext: ext-camera-only
 bluetooth: cic
-storage: sdcard-mmc0-usb-sd(adoptablesd=false,adoptableusb=false)
+storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=true)


### PR DESCRIPTION
Enable adoptablesd for CIC in mixin spec
The device will be able to push files to
sd card using adb.

Tracked-On: OAM-91550
Signed-off-by: nitishat <nitisha.tomar@intel.com>