### PR TITLE
Disable neural networks

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -67,7 +67,6 @@ vndk: true
 public-libraries: true
 device-specific: caas
 hdcpd: true
-neuralnetworks: true
 treble: true
 swap: zram_auto(size=1073741824,swappiness=true,hardware=gordon_peak)
 art-config: true


### PR DESCRIPTION
As NN inferencing not yet enabled in CIV, removing the enablement
patches to skip NNAPI CTS tests.

Tracked-On: OAM-91618
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>