### PR TITLE
mixins.spec: Update usb-gadget option

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -34,7 +34,7 @@ wlan: auto
 codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt, profile_file=media_profiles_1080p.xml)
 codec2: true
 usb: host
-usb-gadget: configfs(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.1.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)
+usb-gadget: auto(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.2.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)
 midi: true
 touch: cvt0f21
 navigationbar: true


### PR DESCRIPTION
Target should auto-detect USB Device Controller.
Hence, change mixins.spec to auto option for usb-gadget.
Also, change the default UDC name to "dwc3.2.auto".

Tracked-On: OAM-91635
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>