### PR TITLE
Increase the super_partition_size for opencl so files integration.

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -77,7 +77,7 @@ factory-scripts: true
 filesystem_config: common
 load_modules: true
 gptbuild: true(size=32G,generate_craff=false,compress_gptimage=true)
-dynamic-partitions: true(super_img_in_flashzip=true)
+dynamic-partitions: true(super_img_in_flashzip=true, super_partition_size=8000)
 dbc: true
 atrace: true
 firmware: true(all_firmwares=true)


### PR DESCRIPTION
Existing partition size is too small to include opencl so files.
This caused the pre-integration build failure. So we extend the
size accordingly.

Change-Id: I6926a08c0d8c83186a01392aea8b201474684c61
Tracked-On: OAM-92070
Signed-off-by: Wan Shuang <shuang.wan@intel.com>