### PR TITLE
Enable selinux for android 11 on Celadon

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -10,7 +10,7 @@ product.mk: device.mk
 kernel: gmin64(useprebuilt=false,src_path=kernel/lts2019-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2019-chromium, more_modules=true, yocto_src_path=kernel/lts2019-yocto, yocto_cfg_path=config-lts/lts2019-yocto, chromium_src_path=kernel/lts2019-chromium, chromium_cfg_path=config-lts/lts2019-chromium)
 disk-bus: auto
 boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true)
-sepolicy: permissive
+sepolicy: enforcing
 bluetooth: auto(ivi=false)
 audio: project-celadon
 vendor-partition: true(partition_size=600,partition_name=vendor)


### PR DESCRIPTION
Basing on the requirement, selinux should be enabled on
Celadon with android 11.

Tracked-On: OAM-92984
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>