### PR TITLE
mixins.spec: Enable new mixin for storage

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -26,7 +26,7 @@ dexpreopt: true
 pstore: false
 media: auto(add_sw_msdk=false, opensource_msdk=true, opensource_msdk_omx_il=true)
 graphics: auto(gen9+=true,hwc2=true,vulkan=true,drmhwc=false,minigbm=true,gralloc1=true,enable_guc=false)
-storage: sdcard-mmc0-v-usb-sd(adoptablesd=false,adoptableusb=false)
+storage: sdcard-mmc0-v-usb-sd-r(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)


### PR DESCRIPTION
This patch enables new mixin for storage in
R dessert.

Tracked-On: OAM-92905
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>