### PR TITLE
[REVERT ME] Change wlan mixins to legacy mode

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -30,7 +30,7 @@ storage: sdcard-mmc0-v-usb-sd(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
-wlan: auto
+wlan: iwlwifi(libwifi-hal=true)
 codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=bxt, profile_file=media_profiles_1080p.xml)
 codec2: true
 usb: host


### PR DESCRIPTION
As Wi-Fi drivers are not getting loaded due to aaf missing
capabilities, revert back to legacy mode(insmod) of
loading drivers.

Tracked-On: OAM-93073
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>