### PR TITLE
mixins.spec: Enable health hal

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -55,7 +55,7 @@ intel_prop: true
 trusty: true(ref_target=celadon_64)
 memtrack: true
 avb: true
-health: false
+health: hal
 slot-ab: true
 abota-fw: true
 firststage-mount: true


### PR DESCRIPTION
This patch adds Intel health hal in mixins.

Tracked-On: OAM-92794
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>