### PR TITLE
Enabling mainline module dependency from mixin-spec

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -84,3 +84,4 @@ firmware: true(all_firmwares=true)
 aaf: true
 suspend: auto
 sensors: mediation
+mainline-mod: true


### PR DESCRIPTION
Enables the newly added mixin for mainline module dep.
The enables the device to go for userspace reboot, updatable apex etc.

Tracked-On: OAM-94279
Signed-off-by: N, Shyjumon <shyjumon.n@intel.com>