### PR TITLE
[DONOT MERGE] Enable gatekeeper software HAL

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -52,7 +52,8 @@ lights: true
 power: true(power_throttle=true)
 debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
-trusty: true(ref_target=celadon_64)
+trusty: false
+gatekeeperSW: true
 memtrack: true
 avb: true
 health: hal


### PR DESCRIPTION
This patch enables the gatekeeper SW HAL.
It is used when trusty is disabled for screen lock.

Tracked-On: OAM-94278
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>