### PR TITLE
Disable usb-audio driver loading as modules

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -62,7 +62,7 @@ abota-fw: true
 firststage-mount: true
 cpuset: autocores
 usb-init: true
-usb-audio-init: true
+usb-audio-init: false
 usb-otg-switch: true
 vndk: true
 public-libraries: true


### PR DESCRIPTION
usb audio drivers are made as static

Tracked-On:OAM-94556
Signed-off-by: Deepa G K <g.k.deepa@intel.com>
Signed-off-by: Balaji Manoharan m.balaji@intel.com