### PR TITLE
Fix for CtsTelephonyTestcases.

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -76,6 +76,7 @@ debugfs: true
 disk-encryption: true
 factory-scripts: true
 filesystem_config: common
+telephony: false
 load_modules: true
 gptbuild: true(size=32G,generate_craff=false,compress_gptimage=true)
 dynamic-partitions: true(super_img_in_flashzip=true)


### PR DESCRIPTION
CTS telephone test cases are failing.
Disable the ril flag to disable telephony feature
to pass the telephony test cases.

Change-Id: Ie8e2e2a36cbc8ecf36aec423659924d9b37c8e70
Tracked-On: OAM-95318
Signed-off-by: rramakax <rohitx.kant@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>