### PR TITLE
Change bluetooth mixin from auto to btusb

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -11,7 +11,7 @@ kernel: gmin64(useprebuilt=false,src_path=kernel/lts2019-chromium, loglevel=7, i
 disk-bus: auto
 boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true)
 sepolicy: enforcing
-bluetooth: auto(ivi=false)
+bluetooth: btusb(ivi=false)
 audio: project-celadon
 vendor-partition: true(partition_size=600,partition_name=vendor)
 acpio-partition: true(partition_size=2)


### PR DESCRIPTION
Bluetooth drivers are not getting loaded with aafd.

Changed the mixin from auto to btusb to make sure bluetooth
drivers are loaded on post-fs.

Tracked-On: OAM-93634
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>