### PR TITLE
Fix for CtsDevicePolicyManagerTestCases

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -85,3 +85,4 @@ firmware: true(all_firmwares=false)
 aaf: true
 suspend: auto
 sensors: mediation
+bugreport: true


### PR DESCRIPTION
testAdminActionBookkeeping is failing.

Actviitymanager is starting the service bugreport
(/system/bin/dumpstate) but we dont have this Service in
init.rc file. added the service in init.rc file by making
bugreport true in mixin spec.

Change-Id: Ib7ee31ba9317d4ea55e3d0b4af175f78900f95e8
Tracked-On: OAM-95340
Signed-off-by: Gururaj, Patil <gururajx.patil@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>