### PR TITLE
Enable mainline module dependency from mixin-spec

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -87,3 +87,4 @@ aaf: true
 suspend: auto
 sensors: mediation
 bugreport: true
+mainline-mod: true


### PR DESCRIPTION
Tracked-On: OAM-95459
Signed-off-by: svenate <salini.venate@intel.com>