### PR TITLE
Reverting back USB accessory change

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -34,7 +34,7 @@ rfkill: true(force_disable=)
 wlan: iwlwifi(libwifi-hal=true)
 codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=cml, profile_file=media_profiles_1080p.xml, gpu=gen9)
 codec2: true
-usb: host+acc
+usb: host
 usb-gadget: auto(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.2.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)
 midi: true
 touch: cvt0f21


### PR DESCRIPTION
Mixinup for USB accessory feature revert

We do not support USB accessory feature
hence reverting changes from mixins.spec file

Change-Id: I45e8c83a3190075a4a1a3bc4960c9d9849e19415
Tracked-On: OAM-97422
Signed-off-by: rprajapx <ravindrax.prajapati@intel.com>