### PR TITLE
Enable sw_omx_video on caas_cfc

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -32,7 +32,7 @@ ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
 wlan: iwlwifi(libwifi-hal=true)
-codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=tgl, profile_file=media_profiles_1080p.xml, gpu=gen12)
+codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, sw_omx_video=false, platform=tgl, profile_file=media_profiles_1080p.xml, gpu=gen12)
 codec2: true
 usb: host
 usb-gadget: auto(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.2.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)

--- a/caas_cfc/mixins.spec
+++ b/caas_cfc/mixins.spec
@@ -32,7 +32,7 @@ ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
 wlan: iwlwifi(libwifi-hal=true)
-codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, platform=cml, profile_file=media_profiles_1080p.xml, gpu=gen9)
+codecs: configurable(hw_ve_h265=true, hw_vd_vp9=true, hw_vd_mp2=true, hw_vd_vc1=false, sw_omx_video=true, platform=cml, profile_file=media_profiles_1080p.xml, gpu=gen9)
 codec2: true
 usb: host+acc
 usb-gadget: auto(usb_config=adb,mtp_adb_pid=0x0a5f,ptp_adb_pid=0x0a61,rndis_pid=0x0a62,rndis_adb_pid=0x0a63,bcdDevice=0x0,bcdUSB=0x200,controller=dwc3.2.auto,f_acm=false,f_dvc_trace=true,dvctrace_source_dev=dvcith-0-msc0)


### PR DESCRIPTION
This is to help enable sw_omx_video on caas_cfc
and disable it on caas.

Tracked-On: OAM-98101
Signed-off-by: Chen Tianmi <tianmi.chen@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>