### PR TITLE
enlarge dalvik vm heapgrowthlimit

### DIFF
--- a/caas_cfc/mixins.spec
+++ b/caas_cfc/mixins.spec
@@ -20,7 +20,7 @@ config-partition: true
 product-partition: true
 odm-partition: true
 display-density: medium
-dalvik-heap: tablet-10in-xhdpi-2048
+dalvik-heap: tablet-7in-400dpi-4096
 cpu-arch: x86
 allow-missing-dependencies: true
 dexpreopt: true


### PR DESCRIPTION
enlarge max heap from 192m to 288m, improve xueersi's
stability.

Tracked-On: OAM-100046
Signed-off-by: Yang, Dong <dong.yang@intel.com>