### PR TITLE
Add an option for vendor-boot group

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -14,7 +14,7 @@ sepolicy: enforcing
 bluetooth: btusb(ivi=false)
 audio: project-celadon
 vendor-partition: true(partition_size=600,partition_name=vendor)
-vendor-boot: true(partition_size=16)
+vendor-boot: true(partition_size=16,bootconfig_enable=true)
 acpio-partition: true(partition_size=2)
 config-partition: true
 product-partition: true


### PR DESCRIPTION
Add an option for vendor-boot group to control the bootconfig
feature.

Tracked-On: OAM-100125
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>