### PR TITLE
Remove the avb mixin group and add tpm mixin group

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -55,7 +55,7 @@ debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: true(ref_target=celadon_64)
 memtrack: false
-avb: true
+tpm: true
 avx: auto
 health: hal
 slot-ab: true

--- a/caas_cfc/mixins.spec
+++ b/caas_cfc/mixins.spec
@@ -55,7 +55,7 @@ debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: false
 memtrack: true
-avb: true
+tpm: false
 avx: auto
 health: hal
 slot-ab: true

--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -52,7 +52,7 @@ debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: true(ref_target=celadon_64)
 memtrack: true
-avb: true
+tpm: true
 health: true
 slot-ab: true
 abota-fw: true

--- a/celadon_tablet/mixins.spec
+++ b/celadon_tablet/mixins.spec
@@ -51,7 +51,7 @@ debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: true(ref_target=celadon_64)
 memtrack: true
-avb: true
+tpm: true
 health: true
 slot-ab: true
 abota-fw: true


### PR DESCRIPTION
1. avb(android verified boot) feature is always enabled in
bootloader, so the avb mixin group that's used to
disable/enable the avb feature is meaningless now.
2. Add the tpm mixin group, so the tpm feature can be
enabled/disabled by mixin config.

Tracked-On: OAM-100190
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>