### PR TITLE
Remove Thermal Service for PGP.

### DIFF
--- a/caas_cfc/mixins.spec
+++ b/caas_cfc/mixins.spec
@@ -43,7 +43,7 @@ device-type: tablet
 debug-tools: true
 fota: true
 default-drm: true
-thermal: thermal-daemon
+thermal: false
 serialport: ttyS0
 flashfiles: ini(fast_flashfiles=false, oemvars=false,installer=true,flash_dnx_os=false,blank_no_fw=true,version=3.0)
 net: common


### PR DESCRIPTION
Removed Thermal Daemon Service for PGP Devices.

Tracked-On: OAM-100352
Signed-off-by: vilasrk <vilas.r.k@intel.com>