### PR TITLE
enable houdini for android S

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -88,3 +88,4 @@ suspend: auto
 sensors: mediation
 bugreport: true
 mainline-mod: true
+houdini: true


### PR DESCRIPTION
We turned on the Houdini switch, no related binary files were included

Signed-off-by: kexx <xiaox.ke@intel.com>