### PR TITLE
sensors disable in PGP

### DIFF
--- a/caas_cfc/mixins.spec
+++ b/caas_cfc/mixins.spec
@@ -85,7 +85,7 @@ atrace: true
 firmware: true(all_firmwares=false)
 aaf: cfc
 suspend: auto
-sensors: mediation
+sensors: mediation(enable_sensor_list=false)
 bugreport: true
 mainline-mod: true
 houdini: true


### PR DESCRIPTION
sensors 1.0 and 2.0 services disable and enable

Tracked-On: OAM-100260
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>