### PR TITLE
turn on Houdini in mixins.spec

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -88,3 +88,4 @@ suspend: auto
 sensors: mediation
 bugreport: true
 mainline-mod: true
+houdini: true


### PR DESCRIPTION
sepolicy for Houdini is merged, it's right time to turn on Houdini

Tracked-On: OAM-100891
Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>