### PR TITLE
upgrading sensors@1.0-service to sensors@2.0-service in Android_S

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -85,7 +85,7 @@ atrace: true
 firmware: true(all_firmwares=false)
 aaf: true
 suspend: auto
-sensors: mediation
+sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true
 houdini: true


### PR DESCRIPTION
enable sensors in caas

mixin.spec changes to enable sensors

Tracked-On: OAM-101153
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>