### PR TITLE
Revert "This patch is to disable UDC for now"

### DIFF
--- a/caas/fstab
+++ b/caas/fstab
@@ -9,7 +9,7 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 system   /system  ext4 ro,barrier=1 wait,slotselect,avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey,avb=vbmeta,logical,first_stage_mount
 /dev/block/by-name/vbmeta       /vbmeta         emmc    defaults                                                   defaults,slotselect,avb
-/dev/block/by-name/userdata         /data           ext4    noatime,nosuid,nodev,noauto_da_alloc,errors=panic   wait,check,formattable,fileencryption=aes-256-xts:aes-256-cts,quota,reservedsize=50m,fsverity,latemount,keydirectory=/metadata/vold/metadata_encryption
+/dev/block/by-name/userdata         /data           ext4    noatime,nosuid,nodev,noauto_da_alloc,errors=panic   wait,check,formattable,fileencryption=aes-256-xts:aes-256-cts,quota,reservedsize=50m,fsverity,latemount,keydirectory=/metadata/vold/metadata_encryption,checkpoint=block
 /dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults,slotselect,avb
 /dev/block/by-name/misc         /misc           emmc    defaults                                                    defaults
 /dev/block/by-name/tos          /tos            emmc    defaults                                                    defaults,slotselect,avb

--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -9,7 +9,7 @@ product.mk: device.mk
 [groups]
 kernel: gmin64(useprebuilt=false,src_path=kernel/lts2020-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2020-chromium, more_modules=true, chromium_src_path=kernel/lts2019-chromium, chromium_cfg_path=config-lts/lts2019-chromium, lts2020_yocto_src_path=kernel/lts2020-yocto, lts2020_yocto_cfg_path=config-lts/lts2020-yocto, lts2020_chromium_src_path=kernel/lts2020-chromium, lts2020_chromium_cfg_path=config-lts/lts2020-chromium)
 disk-bus: auto
-boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=false)
+boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=true)
 sepolicy: enforcing
 bluetooth: btusb(ivi=false)
 audio: project-celadon


### PR DESCRIPTION
This reverts commit 23f1b607ef081ac57f6bf7087f32d0a7b357fa8d.

This change is to enable android UDC.

Tracked-On: OAM-102792
Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>