### PR TITLE
System Property for Disabling I/P Devices.

### DIFF
--- a/celadon_ivi/system.prop
+++ b/celadon_ivi/system.prop
@@ -11,3 +11,4 @@ audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
 ro.incremental.enable=yes
+persist.sys.disable.deviceid 0


### PR DESCRIPTION
Added system property which will act as
a trigger point to disable input devices

Tracked-On: OAM-104286
Signed-off-by: Vilas R K <vilas.r.k@intel.com>