### PR TITLE
enable_guc to address android boot issue in sriov mode

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -26,7 +26,7 @@ allow-missing-dependencies: true
 dexpreopt: true
 pstore: false
 media: auto(enable_msdk_omx=false, add_sw_msdk=false, opensource_msdk=true, opensource_msdk_omx_il=false)
-graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=false)
+graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=true)
 storage: sdcard-v-usb-only(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only

--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -26,7 +26,7 @@ allow-missing-dependencies: true
 dexpreopt: true
 pstore: false
 media: auto(enable_msdk_omx=false, add_sw_msdk=false, opensource_msdk=true, opensource_msdk_omx_il=false)
-graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=false)
+graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=true)
 #storage: sdcard-mmc0-v-usb-sd-r(adoptablesd=false,adoptableusb=false)
 storage: sdcard-v-usb-only(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp

--- a/celadon_tablet/mixins.spec
+++ b/celadon_tablet/mixins.spec
@@ -23,7 +23,7 @@ allow-missing-dependencies: true
 dexpreopt: true
 pstore: ram_dummy(address=0x50000000,size=0x400000,record_size=0x4000,console_size=0x200000,ftrace_size=0x2000,dump_oops=1)
 media: mesa(enable_msdk_omx=true, add_sw_msdk=false, opensource_msdk=true, opensource_msdk_omx_il=true)
-graphics: mesa(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=false)
+graphics: mesa(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=true)
 storage: sdcard-mmc0-usb-sd(adoptablesd=true,adoptableusb=true)
 ethernet: dhcp
 camera-ext: ext-camera-only


### PR DESCRIPTION
Without GuC submission enabled, GPU hang seen when Android is booted in sriov mode.

Fix the issue by enabling GuC submission(enable_guc=true).

Tracked-On: OAM-105036
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>