### PR TITLE
Fix VP9 hardware encode failure

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -26,7 +26,7 @@ allow-missing-dependencies: true
 dexpreopt: true
 pstore: false
 media: auto(enable_msdk_omx=false, add_sw_msdk=false, opensource_msdk=true, opensource_msdk_omx_il=false)
-graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=true)
+graphics: auto(gen9+=true,vulkan=true,minigbm=true,gralloc1=true,enable_guc=false)
 storage: sdcard-v-usb-only(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only


### PR DESCRIPTION
VP9 hardware encode fails due to HuC authentication not enabled.

i915 driver can determine the GuC Submission and HuC authentication based on Graphics Gen version but as we are overriding it by setting enable_guc=1, HuC authentication is disabled causing VP9 hardware encode failure.

Fix the issue by disabling overriding of enable_guc parameter.

Tracked-On: OAM-105265
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>