### PR TITLE
[JNI] Disable avx2

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -56,7 +56,7 @@ intel_prop: true
 trusty: true(ref_target=celadon_64)
 memtrack: true
 tpm: true
-avx: auto
+avx: false
 health: hal
 slot-ab: true
 abota-fw: true


### PR DESCRIPTION
Disable avx2 to false from auto as we don't support avx2.

Tracked-On: OAM-105278
Signed-off-by: sushre2x sushreex.panda@intel.com
Signed-off-by: ahs amrita.h.s@intel.com