### PR TITLE
[not to merge] Mixin change for tencent

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -84,7 +84,7 @@ dbc: true
 atrace: true
 firmware: true(all_firmwares=false)
 aaf: true
-suspend: auto
+suspend: never
 sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true


### PR DESCRIPTION
set suspend to never in mixins
for suppressing the suspend activity in tencent.

Signed-off-by: bshwetha <shwetha.b@intel.com>