### PR TITLE
mixinup: Change product model for fix miniworld login fail

### DIFF
--- a/cic_cloud/cic_cloud.mk
+++ b/cic_cloud/cic_cloud.mk
@@ -8,4 +8,4 @@ PRODUCT_AAPT_PREF_CONFIG := mdpi
 PRODUCT_NAME := cic_cloud
 PRODUCT_DEVICE := cic_cloud
 PRODUCT_BRAND := Intel
-PRODUCT_MODEL := CIC container image on cloud device
+PRODUCT_MODEL := ICS3A on cloud


### PR DESCRIPTION
Miniworld app will login failed in our ics3a platform, but login ok in emulator with same app version, we found it's related with product model info.

Tracked-On: OAM-104813
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>