### PR TITLE
project-celadon: mixin changes to enable NeuralNetworks

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -89,3 +89,4 @@ sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true
 houdini: true
+neuralnetworks: true


### PR DESCRIPTION
- Enabled neuralnetworks in mixin.spec

Tracked-On: OAM-105821
Signed-off-by: Nagamani Chennuboina <nagamani.chennuboina@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>