### PR TITLE
Add flag to enable vsock use for remote inference via nnhal

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -89,4 +89,4 @@ sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true
 houdini: true
-neuralnetworks: true
+neuralnetworks: true(vsock-remote-infer=true)


### PR DESCRIPTION
set flag for remote_vsock to true which sets vsock property for caas

Tracked-On: OAM-104143