### PR TITLE
Add docker mixins option to celadon_ivi

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -89,3 +89,4 @@ sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true
 houdini: true
+docker: true


### PR DESCRIPTION
Integrate Docker runtime into Android image instead of post-installation.

Tracked-On: OAM-108905