### PR TITLE
[iwlwifi] Disable iwl_7000_drv flag for ivi

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -31,7 +31,7 @@ storage: sdcard-mmc0-v-usb-sd-r(adoptablesd=false,adoptableusb=false)
 ethernet: dhcp
 camera-ext: ext-camera-only
 rfkill: true(force_disable=)
-wlan: iwlwifi(libwifi-hal=true)
+wlan: iwlwifi(libwifi-hal=true, iwl_7000_drv=false)
 codecs: configurable(sw_omx_video=false, hw_omx_video=false, platform=tgl, profile_file=media_profiles_1080p.xml, gpu=gen12)
 codec2: true(enable_msdk_c2=true, use_onevpl=true, platform=adl, hw_ve_vp9=true, hw_vd_vp8=false)
 usb: host


### PR DESCRIPTION
iwl_7000_drv flag is enabled for caas to load iwl7000 driver which is not applicable for celadon_ivi as it uses iwl7000 driver from upstream.

Changes made to disable iwl_7000_drv flag to load upstream driver.

Tracked-On: OAM-108959