### PR TITLE
Enable codec2 with enable_hw option set to false

### DIFF
--- a/cic_cloud/mixins.spec
+++ b/cic_cloud/mixins.spec
@@ -24,4 +24,4 @@ neuralnetworks: true
 power: dummy
 sensors: remote
 wlan: dummy
-codec2: false
+codec2: true(enable_hw=false)


### PR DESCRIPTION
Both OMX and codec2.0 is enabled to make sure all dependent binaries are built to avoid more packages are kept as prebuilt in enable-codec2 pre-update folder. As OMX hardware codecs are enabled by default, disable codec2 hardware codecs by setting option enable_hw to false.

Tracked-On: OAM-111155