### PR TITLE
Enable TPM module in mixins.spec

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -54,7 +54,7 @@ debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: false
 memtrack: true
-tpm: false
+tpm: true
 avx: auto
 health: hal
 slot-ab: true


### PR DESCRIPTION
TPM is used to secure storage for lock state and rollback index

Tracked-On: OAM-111242