### PR TITLE
Fix to load dwc3 driver.

### DIFF
--- a/celadon_ivi/extra_files/usb-init/load_usb_modules.in
+++ b/celadon_ivi/extra_files/usb-init/load_usb_modules.in
@@ -6,4 +6,4 @@ load_usb_modules() {
     insmod $modules/dwc3-pci.ko
     setprop sys.usb.config $(getprop sys.usb.config)
 }
-load_usb_modules&
+load_usb_modules


### PR DESCRIPTION
This fix will help to load dwc3 driver during boot, which will help to enable device mode.