### PR TITLE
Userdata checkpoint configure enable

### DIFF
--- a/celadon_ivi/0001-Userdata-checkpoint-configure-enable.patch
+++ b/celadon_ivi/0001-Userdata-checkpoint-configure-enable.patch
@@ -1,0 +1,32 @@
+From dc5c9729df84c49bee3b7ac73e8110600af1942f Mon Sep 17 00:00:00 2001
+From: "Kang, Zecheng" <zecheng.kang@intel.com>
+Date: Mon, 7 Aug 2023 14:55:58 +0800
+Subject: [PATCH] Userdata checkpoint configure enable
+
+Checkpoint feature need enable in ota
+userdata_checkpoint should enable first in this configuration
+Checkpoint feature enable must depends on userdata_checkpoint=true in
+mixins.spec and CONFIGURE_DM_BOW in x86_64_defconfig
+
+Tracked-On: OAM-110267
+Signed-off-by: Kang, Zecheng <zecheng.kang@intel.com>
+---
+ celadon_ivi/mixins.spec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/celadon_ivi/mixins.spec b/celadon_ivi/mixins.spec
+index 506dca42..532baf13 100755
+--- a/celadon_ivi/mixins.spec
++++ b/celadon_ivi/mixins.spec
+@@ -9,7 +9,7 @@ product.mk: device.mk
+ [groups]
+ kernel: gmin64(useprebuilt=false,src_path=kernel/linux-intel-lts2021, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/linux-intel-lts2021, more_modules=true, chromium_src_path=kernel/lts2019-chromium, chromium_cfg_path=config-lts/lts2019-chromium, lts2020_yocto_src_path=kernel/lts2020-yocto, lts2020_yocto_cfg_path=config-lts/lts2020-yocto, lts2020_chromium_src_path=kernel/lts2020-chromium, lts2020_chromium_cfg_path=config-lts/lts2020-chromium, linux_intel_lts2021_src_path=kernel/linux-intel-lts2021, linux_intel_lts2021_cfg_path=config-lts/linux-intel-lts2021)
+ disk-bus: auto
+-boot-arch: project-celadon(fw_sbl=true,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=celadon_ivi,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=false)
++boot-arch: project-celadon(fw_sbl=true,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=celadon_ivi,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=true)
+ sepolicy: permissive
+ bluetooth: btusb(ivi=false)
+ audio: project-celadon(ivi=true)
+-- 
+2.17.1
+


### PR DESCRIPTION
Checkpoint feature need enable in ota
userdata_checkpoint should enable first in this configuration Checkpoint feature enable must depends on userdata_checkpoint=true in mixins.spec and CONFIGURE_DM_BOW in x86_64_defconfig

Tracked-On: OAM-110267
Signed-off-by: Kang, Zecheng <zecheng.kang@intel.com>