### PR TITLE
Enable optee in celadon ivi mixins.spec

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -53,6 +53,7 @@ power: true(power_throttle=true)
 debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
 trusty: false
+optee: true
 memtrack: true
 tpm: true
 avx: auto


### PR DESCRIPTION
Enable optee for celadon ivi project to get TEE services running.

Tracked-On: OAM-112045