### PR TITLE
mixin-spec: unify mixin of optee and trusty into tee

### DIFF
--- a/celadon_ivi/mixins.spec
+++ b/celadon_ivi/mixins.spec
@@ -52,7 +52,7 @@ lights: true
 power: true(power_throttle=true)
 debug-usb-config: true(source_dev=dvcith-0-msc0)
 intel_prop: true
-trusty: false
+tee: false
 memtrack: true
 tpm: true
 avx: auto


### PR DESCRIPTION
tee has 3 configurations:
-false:  none tee will be provided
-trusty: use trusty os for tee
-optee:  use optee os for tee

by default it will be set as false.

Tracked-On: OAM-112562