### PR TITLE
Move AndroidProducts.mk to each target

### DIFF
--- a/celadon_ivi/AndroidProducts.mk
+++ b/celadon_ivi/AndroidProducts.mk
@@ -14,14 +14,8 @@
 # limitations under the License.
 #
 
-PRODUCT_MAKEFILES := \
-    $(LOCAL_DIR)/celadon_ivi/celadon_ivi.mk \
-    $(LOCAL_DIR)/apollo_ivi/apollo_ivi.mk \
-    $(LOCAL_DIR)/blizzard_ivi/blizzard_ivi.mk \
-    $(LOCAL_DIR)/everest_ivi/everest_ivi.mk
+PRODUCT_MAKEFILES += \
+    $(LOCAL_DIR)/celadon_ivi.mk \
 
 COMMON_LUNCH_CHOICES += \
     celadon_ivi-userdebug \
-    apollo_ivi-userdebug \
-    blizzard_ivi-userdebug \
-    everest_ivi-userdebug


### PR DESCRIPTION
Currently, one AndroidProducts.mk lists all the available targets. Thus adding any targets require changing this common file.

Moving the AndroidProducts.mk to the target folders so that each target can define the target-specific details.

Tests done:
- Flash and boot
- Wi-Fi scan and connect

Tracked-On: OAM-114075