### PR TITLE
Remove delay for reboot scenario

### DIFF
--- a/caas/guest_pm_control
+++ b/caas/guest_pm_control
@@ -106,18 +106,12 @@ def main():
                         if "guest-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: guest reset request")
-                            cmdCommand = "reboot"
-                            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                            time.sleep(3)
-                            process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE, shell=True)
+                            os.system('reboot')
                             break
                         elif "host-qmp-system-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: Reboot triggered by host")
-                            cmdCommand = "reboot"
-                            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                            time.sleep(3)
-                            process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE, shell=True)
+                            os.system('reboot')
                             break
                         elif "host-qmp-quit" in json.dumps(resp["data"]):
                             print("VM is getting Shutdown")

--- a/caas_dev/guest_pm_control
+++ b/caas_dev/guest_pm_control
@@ -106,18 +106,12 @@ def main():
                         if "guest-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: guest reset request")
-                            cmdCommand = "reboot"
-                            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                            time.sleep(3)
-                            process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE, shell=True)
+                            os.system('reboot')
                             break
                         elif "host-qmp-system-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: Reboot triggered by host")
-                            cmdCommand = "reboot"
-                            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                            time.sleep(3)
-                            process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE, shell=True)
+                            os.system('reboot')
                             break
                         elif "host-qmp-quit" in json.dumps(resp["data"]):
                             print("VM is getting Shutdown")


### PR DESCRIPTION
Remove the delay and use system reboot command
for rebooting the host through guest.
Avoiding the creation of subprocess for reboot.

Tests Done: With guest_pm, reboot of host through
guest takes similar time as that of standalone
host reboot.

Tracked-On: OAM-117374