### PR TITLE
Remove neuralnetworks to reduce image size

### DIFF
--- a/caas_cvmb/mixins.spec
+++ b/caas_cvmb/mixins.spec
@@ -89,4 +89,3 @@ sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true
 houdini: true
-neuralnetworks: true(vsock-remote-infer=true)


### PR DESCRIPTION
As neuralnetworks is not a requirement, remove neuralnetworks to reduce image size.

Tests done:
- Android boot

Tracked-On: OAM-118071