### PR TITLE
Generate qcow2 image for caas_cvmb

### DIFF
--- a/caas_cvmb/mixins.spec
+++ b/caas_cvmb/mixins.spec
@@ -78,7 +78,7 @@ factory-scripts: true
 filesystem_config: common
 telephony: false
 load_modules: true
-gptbuild: true(size=32G,generate_craff=false,compress_gptimage=true)
+gptbuild: true(size=32G,generate_craff=false,compress_gptimage=true,generate_qcow2=true)
 dynamic-partitions: true(super_img_in_flashzip=true,super_partition_size=5000,virtual_ab=true,virtual_ab_compression=true)
 dbc: true
 atrace: true


### PR DESCRIPTION
For caas_cvmb, qcow2 image format is required.

Tracked-On: OAM-118515