### PR TITLE
Removal of unused 6.1 and 5.15 kernels

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -7,7 +7,7 @@ mixinsrel: false
 product.mk: device.mk
 
 [groups]
-kernel: gmin64(useprebuilt=false,src_path=kernel/lts2023-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2023-chromium, more_modules=true, lts2021_chromium_src_path=kernel/lts2021-chromium, lts2021_chromium_cfg_path=config-lts/lts2021-chromium, linux_intel_lts2021_src_path=kernel/linux-intel-lts2021, linux_intel_lts2021_cfg_path=config-lts/linux-intel-lts2021, lts2022_chromium_src_path=kernel/lts2022-chromium, lts2022_chromium_cfg_path=config-lts/lts2022-chromium, linux_intel_lts2022_src_path=kernel/linux-intel-lts2022, linux_intel_lts2022_cfg_path=config-lts/linux-intel-lts2022)
+kernel: gmin64(useprebuilt=false,src_path=kernel/lts2023-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2023-chromium, more_modules=true)
 disk-bus: auto
 boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=true,data_use_f2fs=true,trusty=true)
 sepolicy: enforcing

--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -7,7 +7,7 @@ mixinsrel: false
 product.mk: device.mk
 
 [groups]
-kernel: gmin64(useprebuilt=false,src_path=kernel/lts2023-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2023-chromium, more_modules=true)
+kernel: gmin64(useprebuilt=false,src_path=kernel/lts2023-chromium, loglevel=7, interactive_governor=false, relative_sleepstates=false, modules_in_bootimg=false, external_modules=,debug_modules=, use_bcmdhd=false, use_iwlwifi=false, extmod_platform=bxt, iwl_defconfig=, cfg_path=config-lts/lts2023-chromium, more_modules=true,lts2023_chromium_src_path=kernel/lts2023-chromium, lts2023_chromium_cfg_path=config-lts/lts2023-chromium, linux_intel_lts2023_src_path=kernel/linux-intel-lts2023, linux_intel_lts2023_cfg_path=config-lts/linux-intel-lts2023)
 disk-bus: auto
 boot-arch: project-celadon(uefi_arch=x86_64,fastboot=efi,ignore_rsci=true,disable_watchdog=true,watchdog_parameters=10 30,verity_warning=false,txe_bind_root_of_trust=false,bootloader_block_size=4096,verity_mode=false,disk_encryption=false,file_encryption=true,metadata_encryption=true,fsverity=true,target=caas,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,usb_storage=true,live_boot=true,userdata_checkpoint=true,data_use_f2fs=true,trusty=true)
 sepolicy: enforcing


### PR DESCRIPTION
Removing option paths for following unused kernels from mixins.spec:
- linux-intel-lts2021
- linux-intel-lts2022
- lts2021-chromium
- lts2022-chromium

Tests done:
- Build for all lunch targets

Tracked-On: OAM-124501
Signed-off-by: simonami99 simona.mishra@intel.com