### PR TITLE
Enable npu mixin

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -90,3 +90,4 @@ mainline-mod: true
 houdini: true
 #neuralnetworks: true(vsock-remote-infer=true)
 neuralnetworks: false
+npu: true


### PR DESCRIPTION
Tests done:
- Android build
- Boot and verified npu device /dev/accel0 enumeration.

Tracked-On: OAM-126050