### PR TITLE
Disable suspend to never

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -83,7 +83,7 @@ dbc: true
 atrace: false
 firmware: true(all_firmwares=false)
 aaf: true
-suspend: auto
+suspend: never
 sensors: mediation(enable_sensor_list=true)
 bugreport: true
 mainline-mod: true


### PR DESCRIPTION
CTS issue failed, device going in suspend state

Set suspend to never

Tests Done: Boot test and verify  by cat /sys/power/wake_lock

Tracked-On: