### PR TITLE
Disable ivi flag for caas

### DIFF
--- a/caas/mixins.spec
+++ b/caas/mixins.spec
@@ -56,7 +56,7 @@ tee: trusty(ref_target=celadon_64)
 memtrack: true
 tpm: true
 avx: auto
-health: hal
+health: hal(ivi=false)
 slot-ab: true
 abota-fw: true
 firststage-mount: true(trusty=true)


### PR DESCRIPTION
Disabling ivi flag to differentiate service according
to product.

Tracked-On: OAM-127856