### PR TITLE
Add the graphic config file

### DIFF
--- a/caas/extra_files/graphics/dgpu-renderwlocal.cfg
+++ b/caas/extra_files/graphics/dgpu-renderwlocal.cfg
@@ -1,0 +1,4 @@
+.benchmark.auto
+k.auto:refinery
+k.auto:transfer
+android.vending

--- a/caas_dev/extra_files/graphics/dgpu-renderwlocal.cfg
+++ b/caas_dev/extra_files/graphics/dgpu-renderwlocal.cfg
@@ -1,0 +1,4 @@
+.benchmark.auto
+k.auto:refinery
+k.auto:transfer
+android.vending


### PR DESCRIPTION
Store the dgpu-renderwlocal.cfg vendor/etc/
The dgpu-renderwlocal.cfg is used to save the process that need use dgpu render and local memory.

Tracked-On: OAM-131149